### PR TITLE
Add GitHub community standard files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in the barangay package
+labels: ["bug"]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: "e.g., search('Tongmageng') returns no results when it should"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        ```python
+        from barangay import search
+        results = search("...")
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include stack traces if applicable.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package Version
+      description: Output of `pip show barangay` or the version from pyproject.toml.
+      placeholder: "e.g., 2026.4.13.0"
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python Version
+      description: Your Python version.
+      placeholder: "e.g., 3.13.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Any additional context (OS, virtual environment, etc.).
+      placeholder: "OS: Ubuntu 24.04, uv v0.x.x"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      description: Please confirm the following before submitting.
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I can reproduce this consistently.
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for the barangay package
+labels: ["enhancement"]
+assignees: []
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Describe it here.
+      placeholder: "e.g., I need to search by PSGC code, not just by name."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+      placeholder: "e.g., Add a `search_by_code()` function that accepts a PSGC code and returns the matching administrative division."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Are there any alternative solutions or workarounds you've tried?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, references, or examples that would help.
+      placeholder: "Links to relevant PSGC documentation, other libraries, etc."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      description: Please confirm the following before submitting.
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I have read the Contributing Guide.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Summary
+
+Briefly describe what this PR does and why.
+
+## Related Issue
+
+Closes # (if applicable)
+
+## Changes
+
+-
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Data update (PSGC dataset)
+- [ ] Refactor / cleanup
+
+## Testing
+
+Describe how you tested your changes.
+
+- [ ] Tests pass (`uv run pytest`)
+- [ ] Linting passes (`uv run ruff check .`)
+- [ ] Type checking passes (`uv run mypy`)
+- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
+
+## Checklist
+
+- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
+- [ ] My code follows the project's style conventions
+- [ ] I have added tests for new functionality (if applicable)
+- [ ] I have updated documentation (if applicable)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of `barangay` receives security updates. Older versions are considered end-of-life and will not be patched.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+1. **Do not** open a public GitHub issue for security vulnerabilities.
+2. Send an email to [manuelb@hawitsu.xyz](mailto:manuelb@hawitsu.xyz) with the subject line **`[barangay SECURITY]`** followed by a brief description.
+3. Include as much detail as possible: steps to reproduce, affected component, potential impact, and any proposed fix if available.
+4. You can expect an acknowledgment within **3 business days**, and a follow-up with a resolution timeline or questions within **7 business days**.
+
+## What to Report
+
+- Known vulnerabilities in dependencies that affect `barangay`
+- Code execution vulnerabilities (e.g., injection, deserialization issues)
+- Data integrity issues (e.g., tampered PSGC data sources)
+- Any other security concerns you believe the maintainers should be aware of
+
+## Disclosure Policy
+
+- Vulnerabilities will be disclosed publicly only after a fix has been released.
+- Credit will be given to the reporter (unless anonymity is requested).
+- We follow [Coordinated Vulnerability Disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure) practices.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with vulnerability reporting process, supported versions, and disclosure policy
- Add `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report form
- Add `.github/ISSUE_TEMPLATE/feature_request.yml` — structured feature request form
- Add `.github/PULL_REQUEST_TEMPLATE.md` — PR template with testing checklist

These files satisfy all remaining GitHub community health standards checks.

## Type of Change
- [x] Documentation update
- [x] Refactor / cleanup

## Testing
- [x] Pre-commit hooks pass