### PR TITLE
Add plugin system with psgc-aux-data remote plugin

### DIFF
--- a/barangay/models.py
+++ b/barangay/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, RootModel
-from typing import Literal, Optional, List
+from typing import Any, Literal, Optional, List
 
 
 class BarangayModel(BaseModel):
@@ -16,6 +16,40 @@ class BarangayModel(BaseModel):
     province_or_huc: str
     municipality_or_city: str
     psgc_id: str
+
+
+class PluginExtensionMetadata(BaseModel):
+    """Metadata describing a plugin extension.
+
+    Attributes:
+        name: Name of the plugin extension.
+        description: Optional description of the plugin extension.
+        version: Optional version string of the plugin extension.
+        repository: Optional repository URL for the plugin extension.
+        format: Optional format identifier for the extension data.
+        as_of: Optional date string indicating when the data was current.
+    """
+
+    name: str
+    description: str | None = None
+    version: str | None = None
+    repository: str | None = None
+    format: str | None = None
+    as_of: str | None = None
+
+
+class PluginExtension(BaseModel):
+    """A plugin extension attached to an administrative division.
+
+    Attributes:
+        field_group: Logical grouping name for the extension fields.
+        metadata: Metadata describing the plugin extension.
+        data: Dictionary or list of dictionaries of extension field names to values.
+    """
+
+    field_group: str
+    metadata: PluginExtensionMetadata
+    data: dict[str, Any] | list[dict[str, Any]]
 
 
 class AdminDivExtended(BaseModel):
@@ -45,6 +79,7 @@ class AdminDivExtended(BaseModel):
     parent_psgc_id: str | Literal["n/a"]
     nicknames: Optional[List[str]] = None
     components: List["AdminDivExtended"] = Field(default_factory=list)
+    extensions: List["PluginExtension"] = Field(default_factory=list)
 
 
 class AdminDiv(RootModel):
@@ -89,6 +124,7 @@ class AdminDivFlat(BaseModel):
         psgc_id: PSGC identifier or 'n/a'.
         parent_psgc_id: Parent PSGC identifier or 'n/a'.
         nicknames: Optional list of alternative names.
+        extensions: List of plugin extensions attached to this division.
     """
 
     name: str
@@ -105,3 +141,4 @@ class AdminDivFlat(BaseModel):
     psgc_id: str | Literal["n/a"]
     parent_psgc_id: str | Literal["n/a"]
     nicknames: Optional[List[str]] = None
+    extensions: List["PluginExtension"] = Field(default_factory=list)

--- a/barangay/plugin_loader.py
+++ b/barangay/plugin_loader.py
@@ -1,0 +1,650 @@
+import csv
+import json
+import logging
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.request import Request, urlopen
+
+import yaml
+
+from barangay.config import get_cache_dir
+from barangay.models import (
+    PluginExtensionMetadata,
+)
+
+logger = logging.getLogger(__name__)
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+_BUILTIN_PLUGINS_DIR = Path(__file__).parent / "plugins"
+
+
+class PluginManifestError(Exception):
+    pass
+
+
+class PluginDataError(Exception):
+    pass
+
+
+def resolve_plugin_sources(
+    env: bool = True,
+    config_file: str | Path | None = None,
+    extra_dirs: list[str | Path] | None = None,
+) -> list[Path]:
+    """Collect plugin directories in priority order (lowest to highest)."""
+    dirs: list[Path] = []
+
+    # 1. Built-in
+    if _BUILTIN_PLUGINS_DIR.is_dir():
+        dirs.append(_BUILTIN_PLUGINS_DIR)
+
+    # 2. Env var
+    if env:
+        env_path = os.environ.get("BARANGAY_PLUGINS_DIR")
+        if env_path:
+            dirs.extend(Path(p) for p in env_path.split(os.pathsep))
+
+    # 3. Config file
+    cfg = _load_project_config(config_file)
+    if cfg and "plugin_dirs" in cfg:
+        for d in cfg["plugin_dirs"]:
+            dirs.append(Path(d))
+
+    # 4. Extra dirs (programmatic)
+    if extra_dirs:
+        dirs.extend(Path(d) for d in extra_dirs)
+
+    return dirs
+
+
+def _load_project_config(config_file: str | Path | None = None) -> dict | None:
+    """Load barangay.yaml or barangay_config.yaml from CWD or parent dirs."""
+    if config_file:
+        path = Path(config_file)
+        if path.is_file():
+            cfg = yaml.safe_load(path.read_text())
+            return cfg if isinstance(cfg, dict) else None
+        return None
+
+    cwd = Path.cwd()
+    candidates = ["barangay.yaml", "barangay_config.yaml"]
+    current = cwd
+    while True:
+        for name in candidates:
+            path = current / name
+            if path.is_file():
+                cfg = yaml.safe_load(path.read_text())
+                return cfg if isinstance(cfg, dict) else None
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+    return None
+
+
+def load_plugin_config(
+    plugin_dirs: list[Path] | None = None,
+) -> dict[str, bool]:
+    """Read and merge plugins.yaml from all source directories.
+
+    Higher-priority sources override enabled status of lower-priority plugins.
+    Returns dict mapping plugin name -> enabled status.
+    """
+    if plugin_dirs is None:
+        plugin_dirs = resolve_plugin_sources()
+
+    merged: dict[str, bool] = {}
+
+    for plugin_dir in plugin_dirs:
+        config_path = plugin_dir / "plugins.yaml"
+        if not config_path.is_file():
+            continue
+        try:
+            cfg = yaml.safe_load(config_path.read_text())
+        except (yaml.YAMLError, OSError) as e:
+            logger.warning("Failed to load %s: %s", config_path, e)
+            continue
+
+        plugins_list = cfg.get("plugins")
+        if not plugins_list or not isinstance(plugins_list, list):
+            continue
+
+        for entry in plugins_list:
+            name = entry.get("name")
+            if not name:
+                continue
+            merged[name] = entry.get("enabled", False)
+
+    return merged
+
+
+def _find_plugin_dir(plugin_name: str, plugin_dirs: list[Path]) -> Path | None:
+    """Find a plugin directory across all source dirs (highest priority wins)."""
+    result: Path | None = None
+    for plugin_dir in plugin_dirs:
+        candidate = plugin_dir / plugin_name
+        if candidate.is_dir():
+            result = candidate
+    return result
+
+
+def load_manifest(
+    plugin_name: str,
+    plugin_dirs: list[Path] | None = None,
+) -> dict[str, Any]:
+    """Read and validate a plugin manifest.
+
+    Required fields: name, format, key.
+    Optional: description, version, repository, ref, current, dates, fields.
+    If 'ref' is omitted and 'repository' is set, defaults to 'main'.
+    Raises PluginManifestError on validation failure.
+    """
+    if plugin_dirs is None:
+        plugin_dirs = resolve_plugin_sources()
+
+    plugin_path = _find_plugin_dir(plugin_name, plugin_dirs)
+    if plugin_path is None:
+        raise PluginManifestError(
+            f"Plugin '{plugin_name}' not found in any plugin directory"
+        )
+
+    manifest_path = plugin_path / "manifest.yaml"
+    if not manifest_path.is_file():
+        raise PluginManifestError(f"Missing manifest.yaml for plugin '{plugin_name}'")
+
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text())
+    except (yaml.YAMLError, OSError) as e:
+        raise PluginManifestError(f"Failed to parse manifest for '{plugin_name}': {e}")
+
+    if not isinstance(manifest, dict):
+        raise PluginManifestError(f"Invalid manifest format for '{plugin_name}'")
+
+    for required in ("name", "format", "key"):
+        if required not in manifest:
+            raise PluginManifestError(
+                f"Missing required field '{required}' in manifest for '{plugin_name}'"
+            )
+
+    return manifest
+
+
+def _is_time_aware(plugin_name: str, plugin_dirs: list[Path] | None = None) -> bool:
+    """Detect whether a plugin is time-aware by scanning its data directory.
+
+    A plugin is time-aware if any subdirectory matches YYYY-MM-DD/.
+    """
+    if plugin_dirs is None:
+        plugin_dirs = resolve_plugin_sources()
+
+    plugin_path = _find_plugin_dir(plugin_name, plugin_dirs)
+    if plugin_path is None:
+        return False
+
+    data_dir = plugin_path / "data"
+    if not data_dir.is_dir():
+        return False
+
+    for entry in data_dir.iterdir():
+        if entry.is_dir() and _DATE_PATTERN.match(entry.name):
+            return True
+
+    return False
+
+
+def resolve_plugin_date(
+    as_of: str | None,
+    plugin_dates: list[str],
+    plugin_current: str,
+) -> str:
+    """Resolve the requested date to the best matching plugin date.
+
+    Uses the same logic as date_resolver.resolve_date():
+    find the closest date <= requested date.
+    Falls back to plugin_current if as_of is None.
+    """
+    if as_of is None:
+        return plugin_current
+
+    if as_of in plugin_dates:
+        return as_of
+
+    dates_before = [d for d in plugin_dates if d <= as_of]
+    if dates_before:
+        return max(dates_before)
+
+    return min(plugin_dates)
+
+
+def load_plugin_data(
+    manifest: dict[str, Any],
+    resolved_date: str | None = None,
+    plugin_dirs: list[Path] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Load plugin data from the appropriate file, returning psgc_id -> {fields}.
+
+    Supports csv, json, and parquet formats.
+    The key column (default: psgc_id) is used for joining but excluded from the data dict.
+
+    If the manifest has a 'repository' field and no local data directory exists,
+    data is fetched from the remote GitHub repository.
+    """
+    if plugin_dirs is None:
+        plugin_dirs = resolve_plugin_sources()
+
+    plugin_name = manifest["name"]
+    fmt = manifest["format"]
+    key = manifest.get("key", "psgc_id")
+
+    plugin_path = _find_plugin_dir(plugin_name, plugin_dirs)
+    if plugin_path is None:
+        return {}
+
+    data_dir = plugin_path / "data"
+
+    if data_dir.is_dir():
+        data_file = _resolve_data_file(
+            data_dir, resolved_date, fmt, plugin_name=plugin_name
+        )
+        if data_file is not None:
+            return _read_data_file(data_file, fmt, key)
+
+    repository = manifest.get("repository")
+    if repository:
+        repo = repository.rstrip("/").split("github.com/")[-1]
+        extensions = {"csv": ".csv", "json": ".json", "parquet": ".parquet"}
+        ext = extensions.get(fmt, f".{fmt}")
+        filename = f"{plugin_name}{ext}"
+
+        ref = manifest.get("ref", "main")
+        if resolved_date:
+            url = f"https://raw.githubusercontent.com/{repo}/{ref}/{resolved_date}/{filename}"
+        else:
+            url = f"https://raw.githubusercontent.com/{repo}/{ref}/{filename}"
+
+        cache_dir = get_cache_dir() / "plugins"
+        cache_file = cache_dir / f"{plugin_name}_{filename}"
+
+        if cache_file.is_file():
+            return _read_data_file(cache_file, fmt, key)
+
+        remote_file = _fetch_remote_data_file(url, plugin_name, cache_dir=cache_dir)
+        return _read_data_file(remote_file, fmt, key)
+
+    return {}
+
+
+def _fetch_remote_data_file(
+    url: str,
+    plugin_name: str,
+    cache_dir: Path | None = None,
+) -> Path:
+    """Download a single file from a remote URL to a cache location.
+
+    Args:
+        url: The remote URL to download.
+        plugin_name: Name of the plugin (used for cache key prefix).
+        cache_dir: Optional override for the cache directory.
+
+    Returns:
+        Path to the cached file.
+
+    Raises:
+        PluginDataError: If the download fails.
+    """
+    if cache_dir is None:
+        cache_dir = get_cache_dir() / "plugins"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = url.rsplit("/", 1)[-1]
+    cache_key = f"{plugin_name}_{filename}"
+    cache_file = cache_dir / cache_key
+
+    if cache_file.is_file():
+        return cache_file
+
+    try:
+        request = Request(url, headers={"User-Agent": "barangay-package"})
+        with urlopen(request, timeout=30) as response:
+            content = response.read()
+        with open(cache_file, "wb") as f:
+            f.write(content)
+        return cache_file
+    except Exception as e:
+        raise PluginDataError(f"Failed to fetch remote file {url}: {e}") from e
+
+
+def _fetch_remote_dates(
+    repo_url: str,
+    cache_dir: Path | None = None,
+) -> list[str]:
+    """Fetch available date directories from a GitHub repository.
+
+    Calls the GitHub API /contents/ endpoint to list root directories,
+    filters for YYYY-MM-DD format, and returns a sorted list.
+
+    Args:
+        repo_url: GitHub repository URL (e.g. https://github.com/user/repo).
+        cache_dir: Optional override for the cache directory.
+
+    Returns:
+        Sorted list of date strings in YYYY-MM-DD format.
+    """
+    repo = repo_url.rstrip("/").split("github.com/")[-1]
+    api_url = f"https://api.github.com/repos/{repo}/contents/"
+
+    if cache_dir is None:
+        cache_dir = get_cache_dir() / "plugins"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    safe_name = repo.replace("/", "_")
+    cache_file = cache_dir / f"{safe_name}_dates.json"
+
+    if cache_file.is_file():
+        try:
+            cached = json.loads(cache_file.read_text())
+            if isinstance(cached, list):
+                return cached
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    try:
+        request = Request(
+            api_url,
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "barangay-package",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode())
+
+        dates = []
+        for item in data:
+            if item.get("type") == "dir":
+                name = item["name"]
+                if _DATE_PATTERN.match(name):
+                    try:
+                        datetime.strptime(name, "%Y-%m-%d")
+                        dates.append(name)
+                    except ValueError:
+                        pass
+
+        dates.sort()
+        cache_file.write_text(json.dumps(dates))
+        return dates
+    except Exception as e:
+        logger.warning("Failed to fetch remote dates for %s: %s", repo_url, e)
+        return []
+
+
+def _resolve_data_file(
+    data_dir: Path,
+    resolved_date: str | None,
+    fmt: str,
+    plugin_name: str | None = None,
+) -> Path | None:
+    """Find the correct data file based on whether plugin is time-aware.
+
+    Time-aware plugins use YYYY-MM-DD/ subdirectories containing plugin_name.<ext>.
+    Non-time-aware plugins use a single plugin_name.<ext> file directly in data/.
+    """
+    extensions = {"csv": ".csv", "json": ".json", "parquet": ".parquet"}
+    ext = extensions.get(fmt, f".{fmt}")
+
+    if resolved_date and plugin_name:
+        date_folder_file = data_dir / resolved_date / f"{plugin_name}{ext}"
+        if date_folder_file.is_file():
+            return date_folder_file
+
+    if plugin_name:
+        named_file = data_dir / f"{plugin_name}{ext}"
+        if named_file.is_file():
+            return named_file
+
+    if plugin_name:
+        for d in sorted(data_dir.iterdir()):
+            if d.is_dir() and _DATE_PATTERN.match(d.name):
+                candidate = d / f"{plugin_name}{ext}"
+                if candidate.is_file():
+                    return candidate
+
+    return None
+
+
+def _read_data_file(
+    data_file: Path,
+    fmt: str,
+    key: str,
+) -> dict[str, dict[str, Any]]:
+    """Read a data file and return psgc_id -> {fields} mapping."""
+    result: dict[str, dict[str, Any]] = {}
+
+    try:
+        if fmt == "csv":
+            with open(data_file, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    psgc_id = row.get(key)
+                    if psgc_id is None:
+                        continue
+                    result[psgc_id] = {k: v for k, v in row.items() if k != key}
+
+        elif fmt == "json":
+            data = json.loads(data_file.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                for item in data:
+                    if not isinstance(item, dict):
+                        continue
+                    psgc_id = item.get(key)
+                    if psgc_id is None:
+                        continue
+                    result[str(psgc_id)] = {k: v for k, v in item.items() if k != key}
+
+        elif fmt == "parquet":
+            import pandas as pd
+
+            df = pd.read_parquet(data_file)
+            if key not in df.columns:
+                return {}
+            for _, row in df.iterrows():
+                psgc_id = str(row[key])
+                result[psgc_id] = {col: row[col] for col in df.columns if col != key}
+    except (OSError, csv.Error, ValueError, json.JSONDecodeError) as e:
+        raise PluginDataError(
+            f"Failed to read plugin data file {data_file}: {e}"
+        ) from e
+    except Exception as e:
+        raise PluginDataError(
+            f"Failed to read plugin data file {data_file}: {e}"
+        ) from e
+
+    return result
+
+
+def _extract_metadata(
+    manifest: dict[str, Any],
+    resolved_date: str | None = None,
+) -> PluginExtensionMetadata:
+    """Extract PluginExtensionMetadata from a manifest."""
+    return PluginExtensionMetadata(
+        name=manifest["name"],
+        description=manifest.get("description"),
+        version=manifest.get("version"),
+        repository=manifest.get("repository"),
+        format=manifest.get("format"),
+        as_of=resolved_date,
+    )
+
+
+def build_plugin_index(
+    as_of: str | None = None,
+    plugin_config: dict[str, bool] | None = None,
+    plugin_dirs: list[Path] | None = None,
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Build psgc_id -> {field_group: {metadata, data}} lookup from all active plugins.
+
+    Args:
+        as_of: Optional date string for historical data resolution.
+        plugin_config: Optional pre-computed plugin config (name -> enabled).
+            If None, loads from disk.
+        plugin_dirs: Optional list of plugin source directories.
+            If None, auto-discovers.
+
+    Returns:
+        Dict mapping psgc_id to a dict of field_group -> {metadata, data}.
+    """
+    if plugin_config is None:
+        plugin_config = load_plugin_config(plugin_dirs=plugin_dirs)
+
+    if plugin_dirs is None:
+        plugin_dirs = resolve_plugin_sources()
+
+    index: dict[str, dict[str, dict[str, Any]]] = {}
+
+    for name, enabled in plugin_config.items():
+        if not enabled:
+            continue
+
+        try:
+            manifest = load_manifest(name, plugin_dirs=plugin_dirs)
+        except PluginManifestError as e:
+            logger.warning("Skipping plugin '%s': %s", name, e)
+            continue
+
+        time_aware = _is_time_aware(name, plugin_dirs=plugin_dirs)
+        repository = manifest.get("repository")
+        resolved_date: str | None = None
+
+        if repository and not time_aware:
+            plugin_dates = manifest.get("dates", [])
+            if not plugin_dates:
+                plugin_dates = _fetch_remote_dates(repository)
+            plugin_current = manifest.get("current", "")
+            if plugin_dates:
+                time_aware = True
+                manifest["dates"] = plugin_dates
+                resolved_date = resolve_plugin_date(as_of, plugin_dates, plugin_current)
+
+        if time_aware and resolved_date is None:
+            plugin_dates = manifest.get("dates", [])
+            plugin_current = manifest.get("current", "")
+            if plugin_dates:
+                resolved_date = resolve_plugin_date(as_of, plugin_dates, plugin_current)
+
+        plugin_data = load_plugin_data(manifest, resolved_date, plugin_dirs=plugin_dirs)
+        meta = _extract_metadata(manifest, resolved_date=resolved_date)
+
+        for psgc_id, fields in plugin_data.items():
+            index.setdefault(psgc_id, {})[name] = {
+                "metadata": meta,
+                "data": fields,
+            }
+
+    return index
+
+
+def enrich_flat(
+    flat_data: list[dict[str, Any]],
+    plugin_index: dict[str, dict[str, dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Attach extensions to each flat record."""
+    for record in flat_data:
+        psgc_id = str(record.get("psgc_id", ""))
+        if psgc_id in plugin_index:
+            record["extensions"] = [
+                {
+                    "field_group": group_name,
+                    "metadata": entry["metadata"],
+                    "data": entry["data"],
+                }
+                for group_name, entry in plugin_index[psgc_id].items()
+            ]
+        else:
+            record["extensions"] = []
+    return flat_data
+
+
+def enrich_extended(
+    node: dict[str, Any],
+    plugin_index: dict[str, dict[str, dict[str, Any]]],
+) -> dict[str, Any]:
+    """Walk the tree and attach extensions to each matching node."""
+    psgc_id = str(node.get("psgc_id", ""))
+    if psgc_id in plugin_index:
+        node["extensions"] = [
+            {
+                "field_group": group_name,
+                "metadata": entry["metadata"],
+                "data": entry["data"],
+            }
+            for group_name, entry in plugin_index[psgc_id].items()
+        ]
+    else:
+        node["extensions"] = []
+    for child in node.get("components", []):
+        enrich_extended(child, plugin_index)
+    return node
+
+
+class PluginLoader:
+    """High-level API for loading barangay data with plugin enrichment."""
+
+    def __init__(
+        self,
+        env: bool = True,
+        config_file: str | Path | None = None,
+        extra_dirs: list[str | Path] | None = None,
+    ):
+        self._plugin_dirs = resolve_plugin_sources(
+            env=env,
+            config_file=config_file,
+            extra_dirs=extra_dirs,
+        )
+        self._plugin_config: dict[str, bool] = load_plugin_config(self._plugin_dirs)
+
+    def add_plugin_dir(self, path: str | Path) -> None:
+        """Add a plugin directory at highest priority."""
+        self._plugin_dirs.append(Path(path))
+        self._plugin_config = load_plugin_config(self._plugin_dirs)
+
+    def enable_plugin(self, name: str) -> None:
+        """Enable a plugin by name."""
+        self._plugin_config[name] = True
+
+    def disable_plugin(self, name: str) -> None:
+        """Disable a plugin by name."""
+        self._plugin_config[name] = False
+
+    def build_index(
+        self, as_of: str | None = None
+    ) -> dict[str, dict[str, dict[str, Any]]]:
+        """Build the plugin index for the given as_of date."""
+        return build_plugin_index(
+            as_of=as_of,
+            plugin_config=self._plugin_config,
+            plugin_dirs=self._plugin_dirs,
+        )
+
+    def enrich_flat(
+        self,
+        flat_data: list[dict[str, Any]],
+        as_of: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Enrich flat records with plugin extensions."""
+        index = self.build_index(as_of=as_of)
+        return enrich_flat(flat_data, index)
+
+    def enrich_extended(
+        self,
+        node: dict[str, Any],
+        as_of: str | None = None,
+    ) -> dict[str, Any]:
+        """Enrich a tree node with plugin extensions."""
+        index = self.build_index(as_of=as_of)
+        return enrich_extended(node, index)

--- a/barangay/plugins/plugins.yaml
+++ b/barangay/plugins/plugins.yaml
@@ -1,0 +1,22 @@
+# Plugin configuration — set enabled: true for any plugin you want to activate.
+#
+# SAMPLE plugins below are bundled for demonstration only and are disabled by
+# default. They contain fabricated data — do not use for real analysis.
+#
+# Plugin types demonstrated:
+#   sample_elevation        — CSV, non-time-aware, scalar dict fields
+#   sample_population       — JSON, time-aware, date-prefixed filenames, scalar dict
+#   sample_schools          — JSON, time-aware, date-prefixed filenames, array data
+#   sample_elevation_time   — JSON, time-aware, YYYY-MM-DD/ folder layout, scalar dict
+
+plugins:
+  - name: sample_elevation
+    enabled: false
+  - name: sample_population
+    enabled: false
+  - name: sample_schools
+    enabled: false
+  - name: sample_elevation_time
+    enabled: false
+  - name: psgc-aux-data
+    enabled: true

--- a/barangay/plugins/psgc-aux-data/manifest.yaml
+++ b/barangay/plugins/psgc-aux-data/manifest.yaml
@@ -1,0 +1,27 @@
+name: psgc-aux-data
+description: Supplementary PSGC data (correspondence codes, old names, city class, income classification, urban/rural, population, status) sourced from official PSA releases.
+version: 0.1.0
+format: json
+key: psgc_id
+repository: https://github.com/bendlikeabamboo/psgc-aux-data-repository
+ref: main
+current: "2026-04-13"
+dates:
+  - "2021-08-19"
+  - "2022-04-29"
+  - "2022-11-08"
+  - "2023-01-25"
+  - "2023-04-18"
+  - "2023-08-15"
+  - "2023-10-24"
+  - "2024-01-23"
+  - "2024-04-23"
+  - "2024-05-08"
+  - "2024-07-12"
+  - "2024-10-18"
+  - "2025-01-30"
+  - "2025-04-23"
+  - "2025-08-29"
+  - "2025-10-13"
+  - "2026-01-13"
+  - "2026-04-13"

--- a/barangay/plugins/sample_elevation/data/sample_elevation.csv
+++ b/barangay/plugins/sample_elevation/data/sample_elevation.csv
@@ -1,0 +1,9 @@
+psgc_id,elevation_m,terrain
+1300000000,16,lowland
+0800000000,52,lowland
+0400000000,322,upland
+1400000000,1500,highland
+1900000000,88,lowland
+0802600000,34,lowland
+0803700000,48,lowland
+1908700000,12,lowland

--- a/barangay/plugins/sample_elevation/manifest.yaml
+++ b/barangay/plugins/sample_elevation/manifest.yaml
@@ -1,0 +1,5 @@
+name: sample_elevation
+description: SAMPLE — Average elevation above sea level (meters) by province. Not real data.
+version: 0.1.0
+format: csv
+key: psgc_id

--- a/barangay/plugins/sample_elevation_time/data/2024-01-15/sample_elevation_time.json
+++ b/barangay/plugins/sample_elevation_time/data/2024-01-15/sample_elevation_time.json
@@ -1,0 +1,8 @@
+[
+  {"psgc_id": "1300000000", "elevation_m": 16, "terrain": "lowland"},
+  {"psgc_id": "0800000000", "elevation_m": 52, "terrain": "lowland"},
+  {"psgc_id": "0400000000", "elevation_m": 322, "terrain": "upland"},
+  {"psgc_id": "1400000000", "elevation_m": 1500, "terrain": "highland"},
+  {"psgc_id": "0802600000", "elevation_m": 34, "terrain": "lowland"},
+  {"psgc_id": "0803700000", "elevation_m": 48, "terrain": "lowland"}
+]

--- a/barangay/plugins/sample_elevation_time/data/2025-01-15/sample_elevation_time.json
+++ b/barangay/plugins/sample_elevation_time/data/2025-01-15/sample_elevation_time.json
@@ -1,0 +1,10 @@
+[
+  {"psgc_id": "1300000000", "elevation_m": 16, "terrain": "lowland"},
+  {"psgc_id": "0800000000", "elevation_m": 52, "terrain": "lowland"},
+  {"psgc_id": "0400000000", "elevation_m": 318, "terrain": "upland"},
+  {"psgc_id": "1400000000", "elevation_m": 1497, "terrain": "highland"},
+  {"psgc_id": "1900000000", "elevation_m": 88, "terrain": "lowland"},
+  {"psgc_id": "0802600000", "elevation_m": 34, "terrain": "lowland"},
+  {"psgc_id": "0803700000", "elevation_m": 48, "terrain": "lowland"},
+  {"psgc_id": "1908700000", "elevation_m": 12, "terrain": "lowland"}
+]

--- a/barangay/plugins/sample_elevation_time/manifest.yaml
+++ b/barangay/plugins/sample_elevation_time/manifest.yaml
@@ -1,0 +1,9 @@
+name: sample_elevation_time
+description: SAMPLE — Elevation data by province with time-versioned snapshots using YYYY-MM-DD/ folder layout. Not real data.
+version: 0.1.0
+format: json
+key: psgc_id
+current: 2025-01-15
+dates:
+  - 2024-01-15
+  - 2025-01-15

--- a/barangay/plugins/sample_population/data/2020-01-01/sample_population.json
+++ b/barangay/plugins/sample_population/data/2020-01-01/sample_population.json
@@ -1,0 +1,7 @@
+[
+  {"psgc_id": "1380100000", "population": 1582050, "households": 345120},
+  {"psgc_id": "1380600000", "population": 1846350, "households": 412890},
+  {"psgc_id": "0831600000", "population": 242540, "households": 52310},
+  {"psgc_id": "1908703000", "population": 327120, "households": 68900},
+  {"psgc_id": "1380200000", "population": 606560, "households": 134200}
+]

--- a/barangay/plugins/sample_population/data/2023-01-01/sample_population.json
+++ b/barangay/plugins/sample_population/data/2023-01-01/sample_population.json
@@ -1,0 +1,7 @@
+[
+  {"psgc_id": "1380100000", "population": 1662000, "households": 368000},
+  {"psgc_id": "1380600000", "population": 1890500, "households": 431200},
+  {"psgc_id": "0831600000", "population": 253480, "households": 55100},
+  {"psgc_id": "1908703000", "population": 349520, "households": 74300},
+  {"psgc_id": "1380200000", "population": 642870, "households": 145600}
+]

--- a/barangay/plugins/sample_population/manifest.yaml
+++ b/barangay/plugins/sample_population/manifest.yaml
@@ -1,0 +1,9 @@
+name: sample_population
+description: SAMPLE — Population counts by city/municipality. Not real data. Demonstrates time-aware JSON plugin with date-versioned snapshots.
+version: 0.1.0
+format: json
+key: psgc_id
+current: 2023-01-01
+dates:
+  - 2020-01-01
+  - 2023-01-01

--- a/barangay/plugins/sample_schools/data/2024-04-13/sample_schools.json
+++ b/barangay/plugins/sample_schools/data/2024-04-13/sample_schools.json
@@ -1,0 +1,82 @@
+[
+  {
+    "psgc_id": "1380100001",
+    "data": [
+      {
+        "beiss_id": 10001,
+        "name": "Caloocan North Elementary School",
+        "classification": "Elementary",
+        "students": 1200
+      },
+      {
+        "beiss_id": 10002,
+        "name": "North City National High School",
+        "classification": "Junior",
+        "students": 850
+      },
+      {
+        "beiss_id": 10003,
+        "name": "Caloocan City Science High School",
+        "classification": "Senior",
+        "students": 420
+      }
+    ]
+  },
+  {
+    "psgc_id": "1380601000",
+    "data": [
+      {
+        "beiss_id": 20001,
+        "name": "Tondo Central School",
+        "classification": "Elementary",
+        "students": 2100
+      },
+      {
+        "beiss_id": 20002,
+        "name": "Tondo National High School",
+        "classification": "Junior",
+        "students": 1600
+      },
+      {
+        "beiss_id": 20003,
+        "name": "Manila Science High School",
+        "classification": "Senior",
+        "students": 680
+      }
+    ]
+  },
+  {
+    "psgc_id": "0831600000",
+    "data": [
+      {
+        "beiss_id": 30001,
+        "name": "Tacloban Central Elementary School",
+        "classification": "Elementary",
+        "students": 980
+      },
+      {
+        "beiss_id": 30002,
+        "name": "Tacloban City National High School",
+        "classification": "Junior",
+        "students": 720
+      }
+    ]
+  },
+  {
+    "psgc_id": "1908703001",
+    "data": [
+      {
+        "beiss_id": 40001,
+        "name": "Bagua Elementary School",
+        "classification": "Elementary",
+        "students": 650
+      },
+      {
+        "beiss_id": 40002,
+        "name": "Bagua Madrasa",
+        "classification": "Elementary",
+        "students": 310
+      }
+    ]
+  }
+]

--- a/barangay/plugins/sample_schools/data/2024-07-13/sample_schools.json
+++ b/barangay/plugins/sample_schools/data/2024-07-13/sample_schools.json
@@ -1,0 +1,100 @@
+[
+  {
+    "psgc_id": "1380100001",
+    "data": [
+      {
+        "beiss_id": 10001,
+        "name": "Caloocan North Elementary School",
+        "classification": "Elementary",
+        "students": 1250
+      },
+      {
+        "beiss_id": 10002,
+        "name": "North City National High School",
+        "classification": "Junior",
+        "students": 890
+      },
+      {
+        "beiss_id": 10003,
+        "name": "Caloocan City Science High School",
+        "classification": "Senior",
+        "students": 450
+      },
+      {
+        "beiss_id": 10004,
+        "name": "Barangay 1 Integrated School",
+        "classification": "Elementary",
+        "students": 520
+      }
+    ]
+  },
+  {
+    "psgc_id": "1380601000",
+    "data": [
+      {
+        "beiss_id": 20001,
+        "name": "Tondo Central School",
+        "classification": "Elementary",
+        "students": 2150
+      },
+      {
+        "beiss_id": 20002,
+        "name": "Tondo National High School",
+        "classification": "Junior",
+        "students": 1650
+      },
+      {
+        "beiss_id": 20003,
+        "name": "Manila Science High School",
+        "classification": "Senior",
+        "students": 710
+      }
+    ]
+  },
+  {
+    "psgc_id": "0831600000",
+    "data": [
+      {
+        "beiss_id": 30001,
+        "name": "Tacloban Central Elementary School",
+        "classification": "Elementary",
+        "students": 1020
+      },
+      {
+        "beiss_id": 30002,
+        "name": "Tacloban City National High School",
+        "classification": "Junior",
+        "students": 750
+      },
+      {
+        "beiss_id": 30004,
+        "name": "Eastern Visayas State University Lab School",
+        "classification": "Senior",
+        "students": 380
+      }
+    ]
+  },
+  {
+    "psgc_id": "1908703001",
+    "data": [
+      {
+        "beiss_id": 40001,
+        "name": "Bagua Elementary School",
+        "classification": "Elementary",
+        "students": 680
+      },
+      {
+        "beiss_id": 40002,
+        "name": "Bagua Madrasa",
+        "classification": "Elementary",
+        "students": 330
+      },
+      {
+        "beiss_id": 40005,
+        "name": "Cotabato City Central Elementary",
+        "classification": "Elementary",
+        "students": 890
+      }
+    ]
+  }
+]

--- a/barangay/plugins/sample_schools/manifest.yaml
+++ b/barangay/plugins/sample_schools/manifest.yaml
@@ -1,0 +1,9 @@
+name: sample_schools
+description: SAMPLE — BEISS school records per barangay. Not real data. Demonstrates array/list data extension where each PSGC ID maps to a list of school records.
+version: 0.1.0
+format: json
+key: psgc_id
+current: 2024-07-13
+dates:
+  - 2024-04-13
+  - 2024-07-13

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -397,4 +397,4 @@ class TestAdminDivFlat:
             "nicknames": None,
         }
         model = AdminDivFlat(**data)
-        assert model.model_dump() == data
+        assert model.model_dump(exclude={"extensions"}) == data

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,672 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from barangay.plugin_loader import (
+    PluginLoader,
+    PluginManifestError,
+    _fetch_remote_data_file,
+    _fetch_remote_dates,
+    build_plugin_index,
+    enrich_extended,
+    enrich_flat,
+    load_manifest,
+    load_plugin_config,
+    load_plugin_data,
+    resolve_plugin_date,
+)
+from barangay.models import (
+    PluginExtension,
+    PluginExtensionMetadata,
+    AdminDivExtended,
+    AdminDivFlat,
+)
+
+
+def _create_plugin(tmp_path, name, manifest, data_files):
+    plugin_dir = tmp_path / name
+    plugin_dir.mkdir()
+    (plugin_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+    data_dir = plugin_dir / "data"
+    data_dir.mkdir()
+    for filename, content in data_files.items():
+        filepath = data_dir / filename
+        filepath.write_text(content) if isinstance(
+            content, str
+        ) else filepath.write_bytes(content)
+    return plugin_dir
+
+
+def _make_manifest(name, fmt="csv", key="psgc_id", **overrides):
+    manifest = {"name": name, "format": fmt, "key": key, **overrides}
+    return manifest
+
+
+class TestResolvePluginDate:
+    def test_none_returns_current(self):
+        assert (
+            resolve_plugin_date(None, ["2020-01-01", "2021-01-01"], "2021-01-01")
+            == "2021-01-01"
+        )
+
+    def test_exact_match(self):
+        assert (
+            resolve_plugin_date(
+                "2020-01-01", ["2020-01-01", "2021-01-01"], "2021-01-01"
+            )
+            == "2020-01-01"
+        )
+
+    def test_closest_before(self):
+        assert (
+            resolve_plugin_date(
+                "2020-06-15", ["2020-01-01", "2021-01-01"], "2021-01-01"
+            )
+            == "2020-01-01"
+        )
+
+    def test_before_all_dates(self):
+        assert (
+            resolve_plugin_date(
+                "2019-01-01", ["2020-01-01", "2021-01-01"], "2021-01-01"
+            )
+            == "2020-01-01"
+        )
+
+    def test_after_all_dates(self):
+        assert (
+            resolve_plugin_date(
+                "2022-06-01", ["2020-01-01", "2021-01-01"], "2021-01-01"
+            )
+            == "2021-01-01"
+        )
+
+
+class TestLoadPluginConfig:
+    def test_loads_from_plugin_dirs(self, tmp_path):
+        plugins_yaml = tmp_path / "plugins.yaml"
+        plugins_yaml.write_text(
+            yaml.dump(
+                {
+                    "plugins": [
+                        {"name": "pop", "enabled": True},
+                        {"name": "elevation", "enabled": False},
+                    ]
+                }
+            )
+        )
+        config = load_plugin_config(plugin_dirs=[tmp_path])
+        assert config == {"pop": True, "elevation": False}
+
+    def test_higher_priority_overrides(self, tmp_path):
+        lower = tmp_path / "lower"
+        lower.mkdir()
+        (lower / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "pop", "enabled": True}]})
+        )
+        higher = tmp_path / "higher"
+        higher.mkdir()
+        (higher / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "pop", "enabled": False}]})
+        )
+        config = load_plugin_config(plugin_dirs=[lower, higher])
+        assert config["pop"] is False
+
+    def test_missing_plugins_yaml_returns_empty(self, tmp_path):
+        config = load_plugin_config(plugin_dirs=[tmp_path])
+        assert config == {}
+
+
+class TestLoadManifest:
+    def test_valid_manifest(self, tmp_path):
+        _create_plugin(
+            tmp_path,
+            "demo",
+            _make_manifest("demo", description="A demo", version="1.0"),
+            {},
+        )
+        manifest = load_manifest("demo", plugin_dirs=[tmp_path])
+        assert manifest["name"] == "demo"
+        assert manifest["format"] == "csv"
+        assert manifest["key"] == "psgc_id"
+        assert manifest["description"] == "A demo"
+        assert manifest["version"] == "1.0"
+
+    def test_missing_required_field(self, tmp_path):
+        bad_manifest = {"name": "demo", "key": "psgc_id"}
+        _create_plugin(tmp_path, "bad", bad_manifest, {})
+        with pytest.raises(PluginManifestError, match="format"):
+            load_manifest("bad", plugin_dirs=[tmp_path])
+
+    def test_plugin_not_found(self, tmp_path):
+        with pytest.raises(PluginManifestError, match="not_found"):
+            load_manifest("not_found", plugin_dirs=[tmp_path])
+
+
+class TestLoadPluginData:
+    def test_load_csv_data(self, tmp_path):
+        csv_content = "psgc_id,population,area\n001,1000,5.2\n002,2000,10.1\n"
+        manifest = _make_manifest("pop", fmt="csv")
+        _create_plugin(tmp_path, "pop", manifest, {"pop.csv": csv_content})
+        data = load_plugin_data(manifest, plugin_dirs=[tmp_path])
+        assert data["001"]["population"] == "1000"
+        assert data["001"]["area"] == "5.2"
+        assert data["002"]["population"] == "2000"
+        assert "psgc_id" not in data["001"]
+
+    def test_load_json_data(self, tmp_path):
+        json_content = json.dumps(
+            [
+                {"psgc_id": "001", "elevation": 100, "zone": "urban"},
+                {"psgc_id": "002", "elevation": 50, "zone": "rural"},
+            ]
+        )
+        manifest = _make_manifest("elev", fmt="json")
+        _create_plugin(tmp_path, "elev", manifest, {"elev.json": json_content})
+        data = load_plugin_data(manifest, plugin_dirs=[tmp_path])
+        assert data["001"]["elevation"] == 100
+        assert data["002"]["zone"] == "rural"
+        assert "psgc_id" not in data["001"]
+
+    def test_missing_data_dir_returns_empty(self, tmp_path):
+        _create_plugin(tmp_path, "nodata", _make_manifest("nodata"), {})
+        manifest = _make_manifest("nodata")
+        data = load_plugin_data(manifest, plugin_dirs=[tmp_path])
+        assert data == {}
+
+    def test_unmatched_psgc_id_excluded(self, tmp_path):
+        csv_content = "psgc_id,value\n001,10\n002,20\n"
+        manifest = _make_manifest("val", fmt="csv")
+        _create_plugin(tmp_path, "val", manifest, {"val.csv": csv_content})
+        data = load_plugin_data(manifest, plugin_dirs=[tmp_path])
+        assert "001" in data
+        assert "002" in data
+        assert len(data) == 2
+
+
+class TestBuildPluginIndex:
+    def test_builds_index_from_enabled_plugins(self, tmp_path):
+        csv_content = "psgc_id,population\n133900000,50000\n"
+        _create_plugin(tmp_path, "pop", _make_manifest("pop"), {"pop.csv": csv_content})
+        (tmp_path / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "pop", "enabled": True}]})
+        )
+        config = load_plugin_config(plugin_dirs=[tmp_path])
+        index = build_plugin_index(plugin_config=config, plugin_dirs=[tmp_path])
+        assert "133900000" in index
+        assert "pop" in index["133900000"]
+        assert index["133900000"]["pop"]["data"]["population"] == "50000"
+
+    def test_disabled_plugins_skipped(self, tmp_path):
+        csv_content = "psgc_id,population\n133900000,50000\n"
+        _create_plugin(tmp_path, "pop", _make_manifest("pop"), {"pop.csv": csv_content})
+        (tmp_path / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "pop", "enabled": False}]})
+        )
+        config = load_plugin_config(plugin_dirs=[tmp_path])
+        index = build_plugin_index(plugin_config=config, plugin_dirs=[tmp_path])
+        assert "133900000" not in index
+
+    def test_plugin_with_manifest_error_skipped(self, tmp_path):
+        bad_dir = tmp_path / "bad"
+        bad_dir.mkdir()
+        (bad_dir / "manifest.yaml").write_text("not: a: valid: yaml: [")
+        config = {"bad": True}
+        index = build_plugin_index(plugin_config=config, plugin_dirs=[tmp_path])
+        assert index == {}
+
+    def test_empty_index_when_no_plugins_enabled(self, tmp_path):
+        config = {}
+        index = build_plugin_index(plugin_config=config, plugin_dirs=[tmp_path])
+        assert index == {}
+
+
+class TestEnrichFlat:
+    def test_records_with_matching_psgc_id_get_extensions(self):
+        meta = PluginExtensionMetadata(name="pop", description="population data")
+        plugin_index = {
+            "001": {
+                "pop": {"metadata": meta, "data": {"population": "1000"}},
+            }
+        }
+        flat_data = [{"psgc_id": "001", "name": "Test"}]
+        result = enrich_flat(flat_data, plugin_index)
+        assert len(result[0]["extensions"]) == 1
+        assert result[0]["extensions"][0]["field_group"] == "pop"
+        assert result[0]["extensions"][0]["data"]["population"] == "1000"
+
+    def test_records_without_match_get_empty_extensions(self):
+        plugin_index = {}
+        flat_data = [{"psgc_id": "001", "name": "Test"}]
+        result = enrich_flat(flat_data, plugin_index)
+        assert result[0]["extensions"] == []
+
+    def test_multiple_plugins_per_record(self):
+        meta1 = PluginExtensionMetadata(name="pop", description="population")
+        meta2 = PluginExtensionMetadata(name="elev", description="elevation")
+        plugin_index = {
+            "001": {
+                "pop": {"metadata": meta1, "data": {"population": "1000"}},
+                "elev": {"metadata": meta2, "data": {"elevation": 100}},
+            }
+        }
+        flat_data = [{"psgc_id": "001", "name": "Test"}]
+        result = enrich_flat(flat_data, plugin_index)
+        assert len(result[0]["extensions"]) == 2
+        groups = {e["field_group"] for e in result[0]["extensions"]}
+        assert groups == {"pop", "elev"}
+
+
+class TestEnrichExtended:
+    def test_matching_node_gets_extensions(self):
+        meta = PluginExtensionMetadata(name="pop", description="population")
+        plugin_index = {
+            "130000000": {
+                "pop": {"metadata": meta, "data": {"population": "50000"}},
+            }
+        }
+        node = {
+            "psgc_id": "130000000",
+            "name": "NCR",
+            "type": "region",
+            "components": [],
+        }
+        result = enrich_extended(node, plugin_index)
+        assert len(result["extensions"]) == 1
+        assert result["extensions"][0]["field_group"] == "pop"
+
+    def test_non_matching_node_gets_empty_extensions(self):
+        plugin_index = {}
+        node = {
+            "psgc_id": "130000000",
+            "name": "NCR",
+            "type": "region",
+            "components": [],
+        }
+        result = enrich_extended(node, plugin_index)
+        assert result["extensions"] == []
+
+    def test_children_also_enriched(self):
+        meta = PluginExtensionMetadata(name="pop", description="population")
+        plugin_index = {
+            "013754000": {
+                "pop": {"metadata": meta, "data": {"population": "2000"}},
+            }
+        }
+        child = {
+            "psgc_id": "013754000",
+            "name": "Barangay 1",
+            "type": "barangay",
+            "components": [],
+        }
+        node = {
+            "psgc_id": "130000000",
+            "name": "NCR",
+            "type": "region",
+            "components": [child],
+        }
+        result = enrich_extended(node, plugin_index)
+        assert result["extensions"] == []
+        assert len(result["components"][0]["extensions"]) == 1
+        assert result["components"][0]["extensions"][0]["data"]["population"] == "2000"
+
+
+class TestTimeAwareness:
+    def test_date_folder_triggers_time_aware(self, tmp_path):
+        plugin_dir = _create_plugin(tmp_path, "ta", _make_manifest("ta"), {})
+        date_dir = plugin_dir / "data" / "2024-01-01"
+        date_dir.mkdir(parents=True)
+        (date_dir / "ta.csv").write_text("psgc_id,val\n001,10\n")
+        from barangay.plugin_loader import _is_time_aware
+
+        assert _is_time_aware("ta", plugin_dirs=[tmp_path]) is True
+
+    def test_plain_filename_triggers_time_unaware(self, tmp_path):
+        _create_plugin(
+            tmp_path, "tu", _make_manifest("tu"), {"tu.csv": "psgc_id,val\n001,10\n"}
+        )
+        from barangay.plugin_loader import _is_time_aware
+
+        assert _is_time_aware("tu", plugin_dirs=[tmp_path]) is False
+
+
+class TestPluginLoader:
+    def test_enable_disable_plugin(self, tmp_path):
+        loader = PluginLoader(env=False, extra_dirs=[])
+        loader.enable_plugin("pop")
+        assert loader._plugin_config["pop"] is True
+        loader.disable_plugin("pop")
+        assert loader._plugin_config["pop"] is False
+
+    def test_add_plugin_dir(self, tmp_path):
+        csv_content = "psgc_id,population\n001,1000\n"
+        _create_plugin(tmp_path, "pop", _make_manifest("pop"), {"pop.csv": csv_content})
+        (tmp_path / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "pop", "enabled": True}]})
+        )
+        loader = PluginLoader(env=False, extra_dirs=[])
+        assert "pop" not in loader._plugin_config
+        loader.add_plugin_dir(tmp_path)
+        assert loader._plugin_config.get("pop") is True
+
+    def test_enrich_flat_with_loader(self, tmp_path):
+        csv_content = "psgc_id,population\n001,1000\n"
+        _create_plugin(tmp_path, "pop", _make_manifest("pop"), {"pop.csv": csv_content})
+        (tmp_path / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "pop", "enabled": True}]})
+        )
+        loader = PluginLoader(env=False, extra_dirs=[tmp_path])
+        flat_data = [{"psgc_id": "001", "name": "Test"}]
+        result = loader.enrich_flat(flat_data)
+        assert len(result[0]["extensions"]) == 1
+        assert result[0]["extensions"][0]["data"]["population"] == "1000"
+
+    def test_enrich_extended_with_loader(self, tmp_path):
+        csv_content = "psgc_id,population\n001,1000\n"
+        _create_plugin(tmp_path, "pop", _make_manifest("pop"), {"pop.csv": csv_content})
+        (tmp_path / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "pop", "enabled": True}]})
+        )
+        loader = PluginLoader(env=False, extra_dirs=[tmp_path])
+        node = {"psgc_id": "001", "name": "Test", "type": "barangay", "components": []}
+        result = loader.enrich_extended(node)
+        assert len(result["extensions"]) == 1
+        assert result["extensions"][0]["data"]["population"] == "1000"
+
+
+class TestModelsExtensionField:
+    def test_admin_div_extended_accepts_extensions(self):
+        ext = PluginExtension(
+            field_group="pop",
+            metadata=PluginExtensionMetadata(name="pop"),
+            data={"population": 1000},
+        )
+        model = AdminDivExtended(
+            name="Test",
+            type="region",
+            psgc_id="130000000",
+            parent_psgc_id="000000000",
+            extensions=[ext],
+        )
+        assert len(model.extensions) == 1
+        assert model.extensions[0].field_group == "pop"
+
+    def test_admin_div_flat_accepts_extensions(self):
+        ext = PluginExtension(
+            field_group="pop",
+            metadata=PluginExtensionMetadata(name="pop"),
+            data={"population": 1000},
+        )
+        model = AdminDivFlat(
+            name="Test",
+            type="region",
+            psgc_id="130000000",
+            parent_psgc_id="000000000",
+            extensions=[ext],
+        )
+        assert len(model.extensions) == 1
+        assert model.extensions[0].field_group == "pop"
+
+    def test_default_extensions_is_empty_list(self):
+        ext_model = AdminDivExtended(
+            name="Test",
+            type="region",
+            psgc_id="130000000",
+            parent_psgc_id="000000000",
+        )
+        assert ext_model.extensions == []
+        flat_model = AdminDivFlat(
+            name="Test",
+            type="region",
+            psgc_id="130000000",
+            parent_psgc_id="000000000",
+        )
+        assert flat_model.extensions == []
+
+    def test_plugin_extension_validation(self):
+        meta = PluginExtensionMetadata(name="demo", version="1.0")
+        ext = PluginExtension(field_group="demo", metadata=meta, data={"key": "val"})
+        assert ext.field_group == "demo"
+        assert ext.metadata.name == "demo"
+        assert ext.metadata.version == "1.0"
+        assert ext.data == {"key": "val"}
+
+
+class TestArrayDataSupport:
+    def test_plugin_extension_accepts_list_data(self):
+        meta = PluginExtensionMetadata(name="schools", description="school list")
+        ext = PluginExtension(
+            field_group="schools",
+            metadata=meta,
+            data=[
+                {"beiss_id": 123, "name": "School A", "classification": "Elementary"},
+                {"beiss_id": 456, "name": "School B", "classification": "Junior"},
+            ],
+        )
+        assert isinstance(ext.data, list)
+        assert len(ext.data) == 2
+        assert ext.data[0]["beiss_id"] == 123
+
+    def test_plugin_extension_accepts_dict_data(self):
+        meta = PluginExtensionMetadata(name="pop", description="population")
+        ext = PluginExtension(
+            field_group="pop",
+            metadata=meta,
+            data={"population": 1000, "area": 5.2},
+        )
+        assert isinstance(ext.data, dict)
+        assert ext.data["population"] == 1000
+
+    def test_enrich_flat_with_array_data(self):
+        meta = PluginExtensionMetadata(name="schools", description="schools")
+        plugin_index = {
+            "001": {
+                "schools": {
+                    "metadata": meta,
+                    "data": [
+                        {"beiss_id": 123, "name": "School A"},
+                        {"beiss_id": 456, "name": "School B"},
+                    ],
+                },
+            }
+        }
+        flat_data = [{"psgc_id": "001", "name": "Test"}]
+        result = enrich_flat(flat_data, plugin_index)
+        assert len(result[0]["extensions"]) == 1
+        assert isinstance(result[0]["extensions"][0]["data"], list)
+        assert result[0]["extensions"][0]["data"][0]["name"] == "School A"
+
+    def test_enrich_extended_with_array_data(self):
+        meta = PluginExtensionMetadata(name="schools", description="schools")
+        plugin_index = {
+            "001": {
+                "schools": {
+                    "metadata": meta,
+                    "data": [{"beiss_id": 123, "name": "School A"}],
+                },
+            }
+        }
+        node = {"psgc_id": "001", "name": "Test", "type": "barangay", "components": []}
+        result = enrich_extended(node, plugin_index)
+        assert len(result["extensions"]) == 1
+        assert isinstance(result["extensions"][0]["data"], list)
+
+    def test_load_json_plugin_with_array_data(self, tmp_path):
+        json_content = json.dumps(
+            [
+                {"psgc_id": "001", "data": [{"beiss_id": 123, "name": "School A"}]},
+                {"psgc_id": "002", "data": [{"beiss_id": 456, "name": "School B"}]},
+            ]
+        )
+        manifest = _make_manifest("schools", fmt="json")
+        _create_plugin(tmp_path, "schools", manifest, {"schools.json": json_content})
+        data = load_plugin_data(manifest, plugin_dirs=[tmp_path])
+        assert isinstance(data["001"]["data"], list)
+        assert data["001"]["data"][0]["beiss_id"] == 123
+        assert "psgc_id" not in data["001"]
+
+
+class TestRemoteFetchDates:
+    @patch("barangay.plugin_loader.urlopen")
+    def test_parses_github_api_response(self, mock_urlopen):
+        api_response = [
+            {"name": "2024-04-13", "type": "dir"},
+            {"name": "README.md", "type": "file"},
+            {"name": "2024-07-13", "type": "dir"},
+            {"name": "not-a-date", "type": "dir"},
+        ]
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(api_response).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        dates = _fetch_remote_dates(
+            "https://github.com/user/repo", cache_dir=tmp_path_factory()
+        )
+        assert dates == ["2024-04-13", "2024-07-13"]
+
+    @patch("barangay.plugin_loader.urlopen")
+    def test_returns_empty_on_failure(self, mock_urlopen):
+        mock_urlopen.side_effect = Exception("network error")
+        dates = _fetch_remote_dates(
+            "https://github.com/user/repo", cache_dir=tmp_path_factory()
+        )
+        assert dates == []
+
+    @patch("barangay.plugin_loader.urlopen")
+    def test_caches_dates_response(self, mock_urlopen, tmp_path):
+        api_response = [{"name": "2024-01-01", "type": "dir"}]
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(api_response).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        dates1 = _fetch_remote_dates(
+            "https://github.com/user/repo", cache_dir=cache_dir
+        )
+        assert dates1 == ["2024-01-01"]
+        assert len(mock_urlopen.call_args_list) == 1
+
+        dates2 = _fetch_remote_dates(
+            "https://github.com/user/repo", cache_dir=cache_dir
+        )
+        assert dates2 == ["2024-01-01"]
+        assert len(mock_urlopen.call_args_list) == 1
+
+
+class TestRemoteFetchDataFile:
+    @patch("barangay.plugin_loader.urlopen")
+    def test_downloads_and_caches(self, mock_urlopen, tmp_path):
+        content = b'{"psgc_id": "001", "value": 42}'
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = content
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        url = "https://raw.githubusercontent.com/user/repo/main/data.json"
+        result = _fetch_remote_data_file(url, "demo", cache_dir=tmp_path)
+        assert result.name == "demo_data.json"
+        assert result.read_bytes() == content
+
+    @patch("barangay.plugin_loader.urlopen")
+    def test_returns_cached_file(self, mock_urlopen, tmp_path):
+        cache_file = tmp_path / "demo_data.json"
+        cache_file.write_bytes(b'{"cached": true}')
+
+        url = "https://raw.githubusercontent.com/user/repo/main/data.json"
+        result = _fetch_remote_data_file(url, "demo", cache_dir=tmp_path)
+        assert result == cache_file
+        mock_urlopen.assert_not_called()
+
+    @patch("barangay.plugin_loader.urlopen")
+    def test_raises_on_download_failure(self, mock_urlopen, tmp_path):
+        mock_urlopen.side_effect = Exception("connection refused")
+        url = "https://raw.githubusercontent.com/user/repo/main/data.json"
+        from barangay.plugin_loader import PluginDataError
+
+        with pytest.raises(PluginDataError, match="Failed to fetch"):
+            _fetch_remote_data_file(url, "demo", cache_dir=tmp_path)
+
+
+class TestRemotePluginLoading:
+    @patch("barangay.plugin_loader._fetch_remote_data_file")
+    def test_load_plugin_data_with_repository(self, mock_fetch, tmp_path):
+        json_content = json.dumps(
+            [
+                {"psgc_id": "001", "schools": [{"name": "School A"}]},
+            ]
+        )
+        cache_file = tmp_path / "demo_data.json"
+        cache_file.write_text(json_content)
+        mock_fetch.return_value = cache_file
+
+        manifest = _make_manifest(
+            "demo", fmt="json", repository="https://github.com/user/repo"
+        )
+        _create_plugin(tmp_path, "demo", manifest, {})
+
+        data = load_plugin_data(
+            manifest, resolved_date="2024-07-13", plugin_dirs=[tmp_path]
+        )
+        assert "001" in data
+        assert data["001"]["schools"][0]["name"] == "School A"
+
+    def test_load_plugin_data_local_wins_over_remote(self, tmp_path):
+        local_json = json.dumps(
+            [
+                {"psgc_id": "001", "value": "local"},
+            ]
+        )
+        manifest = _make_manifest(
+            "demo", fmt="json", repository="https://github.com/user/repo"
+        )
+        _create_plugin(tmp_path, "demo", manifest, {"demo.json": local_json})
+
+        data = load_plugin_data(manifest, plugin_dirs=[tmp_path])
+        assert data["001"]["value"] == "local"
+
+
+class TestRemoteBuildIndex:
+    @patch("barangay.plugin_loader._fetch_remote_dates")
+    @patch("barangay.plugin_loader._fetch_remote_data_file")
+    def test_remote_plugin_auto_discovers_dates(
+        self, mock_fetch_data, mock_fetch_dates, tmp_path
+    ):
+        mock_fetch_dates.return_value = ["2024-04-13", "2024-07-13"]
+        json_content = json.dumps(
+            [
+                {"psgc_id": "001", "value": 42},
+            ]
+        )
+        cache_file = tmp_path / "remote_data.json"
+        cache_file.write_text(json_content)
+        mock_fetch_data.return_value = cache_file
+
+        manifest = _make_manifest(
+            "remote",
+            fmt="json",
+            repository="https://github.com/user/repo",
+            current="2024-07-13",
+        )
+        _create_plugin(tmp_path, "remote", manifest, {})
+        (tmp_path / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "remote", "enabled": True}]})
+        )
+        config = load_plugin_config(plugin_dirs=[tmp_path])
+        index = build_plugin_index(plugin_config=config, plugin_dirs=[tmp_path])
+        assert "001" in index
+        assert "remote" in index["001"]
+
+
+def tmp_path_factory():
+    from tempfile import mkdtemp
+
+    return Path(mkdtemp())

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.2,<3.0.0" },
     { name = "pip", specifier = ">=26.0.1" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "rapidfuzz", specifier = ">=3.14.0,<4.0.0" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "rich", specifier = ">=13.9.0,<14.0.0" },


### PR DESCRIPTION
## Summary

Introduces a config-driven plugin system that enriches PSGC records with auxiliary data from external sources. Plugins are discovered from built-in directories, environment variables, and config files. Data can be local (CSV/JSON/Parquet) or fetched remotely from GitHub repositories with caching. The first real-world plugin, `psgc-aux-data`, pulls supplementary PSA data (correspondence codes, old names, city class, income classification, urban/rural, population, status) from [bendlikeabamboo/psgc-aux-data-repository](https://github.com/bendlikeabamboo/psgc-aux-data-repository).

## Related Issue

#61 

## Changes

- Add `PluginLoader` class with config-driven plugin discovery across multiple source directories (built-in, env var, config file, programmatic)
- Add remote GitHub data fetching with local caching via `_fetch_remote_data_file` and `_fetch_remote_dates`
- Add time-aware date resolution for plugins with historical snapshots (`YYYY-MM-DD/` directory layout)
- Add `enrich_flat()` and `enrich_extended()` functions to attach plugin extensions to flat records and tree nodes
- Add `PluginExtension` and `PluginExtensionMetadata` Pydantic models to `AdminDivFlat` and `AdminDivExtended`
- Add `ref` field to manifest schema to support remote plugins storing data under a specific branch (e.g. `main/{date}/file.json`)
- Add `psgc-aux-data` plugin (remote, time-aware, 18 date snapshots) enabled by default
- Add 4 sample plugins for demonstration (disabled by default)
- Add 49 unit tests for the plugin loader

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Data update (PSGC dataset)
- [ ] Refactor / cleanup

## Testing

All checks performed against `main` base branch:

- [x] Tests pass (`uv run pytest`) — 228 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`) — all checks passed
- [ ] Type checking passes (`uv run mypy`) — `mypy` is not installed as a project dependency
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`) — `ruff`, `ruff-format`, and `pytest` pass; `pip-audit` reports pre-existing vulnerabilities in unrelated dependencies (gitpython, idna, pip, pymdown-extensions, urllib3)

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [x] I have added tests for new functionality (49 tests in `tests/test_plugin_loader.py`)
- [ ] I have updated documentation (if applicable)