### PR TITLE
feat: explode pipeline, plugin CLI integration, and v2026.4.13.1 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ print(results[0]['barangay'])  # Tongmageng
 | 📚 **Multiple Data Models** | Choose the structure that fits your use case |
 | 💾 **Smart Caching** | Automatic caching for faster subsequent loads |
 | 📦 **Ready-to-Use** | JSON, YAML, and Python dictionary formats included |
+| 🧩 **Plug-in System** | Enrich PSGC data with custom extensions via plug-ins |
 
 ---
 
@@ -71,12 +72,19 @@ barangay history search-history "Tongmageng" --as-of "2025-07-08"
 barangay cache info
 barangay cache clear
 
+# Search with plugin enrichment
+barangay search "Tongmageng" --plugin psgc-aux-data --format json
+
+# Export with plugin enrichment
+barangay export --model flat --plugin psgc-aux-data --format json --output enriched.json
+
 # Batch operations
 barangay batch batch-search queries.txt --limit 5 --output results.json
 barangay batch validate barangay_names.txt
 ```
 
 📖 **Full CLI Reference:** [docs/cli.md](https://bendlikeabamboo.github.io/barangay/cli/)
+📖 **Plugin Guide:** [docs/plugins/index.md](https://bendlikeabamboo.github.io/barangay/plugins/)
 
 ---
 

--- a/barangay/__init__.py
+++ b/barangay/__init__.py
@@ -47,6 +47,9 @@ from barangay.config import (  # noqa:E402
     resolve_as_of,
 )
 
+# Import plugin system
+from barangay.plugin_loader import PluginLoader  # noqa:E402
+
 # Update available_dates at module import
 available_dates = list(set(get_available_dates() + [current]))
 
@@ -66,6 +69,7 @@ __all__ = [
     "FuzzBase",
     "BarangayModel",
     "DataManager",
+    "PluginLoader",
     # Data
     "BARANGAY",
     "BARANGAY_EXTENDED",

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@
 - **Historical PSGC Data**: On-demand access to previous PSGC releases by date
 - **Fuzzy Search**: Fast, customizable fuzzy matching
 - **Multiple Data Models**: Basic (nested), Extended (recursive), and Flat (list)
+- **Plug-in System**: Enrich PSGC data with custom extensions via plug-ins (CSV, JSON, Parquet)
 
 ## Installation
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -36,6 +36,7 @@ PSGC ID: 1907005010
 - **Multiple Data Models**: Basic (nested), Extended (recursive), and Flat (list)
 - **Command Line Interface**: Full CLI for search, export, validation, batch operations
 - **Smart Caching**: Automatic local caching for faster subsequent loads
+- **Plug-in System**: Enrich PSGC data with custom extensions (CSV, JSON, Parquet), built-in and remote plugins with time-aware support
 
 ---
 
@@ -259,6 +260,7 @@ barangay search "Tongmageng, Tawi-Tawi"
 barangay search "Tongmageng" --limit 5 --threshold 70.0
 barangay search "Tongmageng" --format json
 barangay search "Tongmageng" --as-of "2025-07-08"
+barangay search "Tongmageng" --plugin psgc-aux-data --format json
 ```
 
 | Option | Type | Default | Description |
@@ -274,6 +276,7 @@ barangay search "Tongmageng" --as-of "2025-07-08"
 barangay export --model flat --format json --output data.json
 barangay export --model basic --format csv --output data.csv
 barangay export --model flat --format json --as-of "2025-07-08" --output historical.json
+barangay export --model flat --plugin psgc-aux-data --format json --output enriched.json
 ```
 
 | Option | Type | Default | Description |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,6 +28,7 @@ print(results[0]["psgc_id"])   # '1907005010'
 - **Three data models** — nested (dict-like), flat (list), extended (recursive with metadata)
 - **CLI included** — search, export, validate, batch operations
 - **Smart caching** — automatic local caching for subsequent loads
+- **Plug-in system** — enrich PSGC data with custom extensions (CSV, JSON, Parquet), built-in and remote plugins supported
 
 ## API Overview
 
@@ -69,7 +70,9 @@ dates = get_available_dates()
 
 ```bash
 barangay search "Tongmageng, Tawi-Tawi"
+barangay search "Tongmageng" --plugin psgc-aux-data --format json
 barangay export --model flat --format json --output data.json
+barangay export --model flat --plugin psgc-aux-data --format json --output enriched.json
 barangay info version
 barangay batch validate names.txt
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barangay"
-version = "2026.4.13.0"
+version = "2026.4.13.1"
 description = "Philippines Standard Geographic Code (PSGC) 2026 Python package, Fuzzy Search, JSON, and YAML."
 authors = [{ name = "bendlikeabamboo", email = "mbalmeo32@gmail.com" }]
 requires-python = ">=3.13"
@@ -42,6 +42,7 @@ dependencies = [
     "click>=8.1.0,<9.0.0",
     "rich>=13.9.0,<14.0.0",
     "tornado>6.5.4",
+    "pyyaml>=6.0.2,<7.0.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "barangay"
-version = "2026.4.13.0"
+version = "2026.4.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -40,6 +40,7 @@ dependencies = [
     { name = "pip" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "requests" },
     { name = "rich" },
@@ -88,6 +89,7 @@ requires-dist = [
     { name = "pip", specifier = ">=26.0.1" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "rapidfuzz", specifier = ">=3.14.0,<4.0.0" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "rich", specifier = ">=13.9.0,<14.0.0" },


### PR DESCRIPTION
## Summary

- **Explode pipeline**: Add `explode.py` with `explode_flat()` to flatten plugin array data into denormalized rows, with classification of scalar vs array plugins and validation
- **Plugin CLI integration**: Add `--plugin` flag to `search` and `export` CLI commands for on-the-fly plugin enrichment
- **Plugin docs**: Full plugin documentation section — overview, CLI reference, Python API, configuration, creating plugins, built-in plugins
- **v2026.4.13.1 prep**: Bump version, add plugin system to all documentation surfaces, export `PluginLoader` from public API, add `pyyaml` as runtime dependency
- **Tests**: Comprehensive test coverage for explode pipeline, CLI plugin integration, and plugin loader

## Test Results

All pre-commit hooks pass: ruff, ruff-format, pip-audit, pytest.