### PR TITLE
docs: comprehensive documentation update for Database API redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,20 @@ pip install barangay
 ```
 
 ```python
-from barangay import search
+from barangay import barangays, search_fuzzy
 
-# Find barangays with fuzzy matching
-results = search("Tongmageng, Tawi-Tawi")
-print(results[0]['barangay'])  # Tongmageng
+# Browse all 42,011 barangays
+print(barangays)  # <PSGC barangay database: 42010 records>
+
+# Get a specific barangay
+brgy = barangays.get(name="Tongmageng")
+print(brgy.region)    # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)  # Tawi-Tawi
+print(brgy.psgc_id)   # 1907005010
+
+# Fuzzy search
+for r in search_fuzzy("Tongmagen, Tawi-Tawi"):
+    print(f"{r.name} — score: {r.score}")
 ```
 
 ---
@@ -32,11 +41,13 @@ print(results[0]['barangay'])  # Tongmageng
 | Feature | Description |
 |---------|-------------|
 | 🔍 **Fuzzy Search** | Fast, customizable matching for unstandardized addresses |
+| 🏛️ **Hierarchy Traversal** | Navigate parent, children, and ancestors of any admin division |
+| 📊 **Pandas Export** | Direct `to_frame()` / `to_dicts()` export from database views |
+| ✅ **Address Validation** | `validate()` and `validate_many()` for automated address checking |
 | 📅 **Historical Data** | Access previous PSGC releases by date |
 | 👩‍💻 **Command Line Interface** | Easy-to-use command line interface |
 | 📚 **Multiple Data Models** | Choose the structure that fits your use case |
 | 💾 **Smart Caching** | Automatic caching for faster subsequent loads |
-| 📦 **Ready-to-Use** | JSON, YAML, and Python dictionary formats included |
 | 🧩 **Plug-in System** | Enrich PSGC data with custom extensions via plug-ins |
 
 ---
@@ -90,27 +101,81 @@ barangay batch validate barangay_names.txt
 
 ## Python API
 
+### Database Views
+
+Pre-built views let you browse and search any admin level directly:
+
+```python
+from barangay import regions, provinces, municipalities, cities, barangays
+
+print(regions)     # <PSGC region database: 18 records>
+print(barangays)   # <PSGC barangay database: 42010 records>
+
+# Look up by name
+brgy = barangays.get(name="Tongmageng")
+print(brgy.province)  # Tawi-Tawi
+
+# Look up by PSGC ID
+brgy = barangays.lookup("1907005010")
+print(brgy)  # <barangay: Tongmageng (1907005010)>
+
+# Iterate over records
+for region in regions:
+    print(region.name)
+```
+
+### Hierarchy Traversal
+
+Each record exposes its position in the administrative hierarchy:
+
+```python
+brgy = barangays.get(name="Tongmageng")
+print(brgy.region)      # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)    # Tawi-Tawi
+print(brgy.municipality)  # Sitangkai
+print(brgy.parent)      # <municipality: Sitangkai (1907005000)>
+print(brgy.ancestors)   # [<municipality: Sitangkai ...>, <province: Tawi-Tawi ...>, ...]
+
+manila = cities.get(name="City of Manila")
+print(manila.children[:2])  # [<submunicipality: Tondo I/II ...>, <submunicipality: Binondo ...>]
+```
+
 ### Fuzzy Search
 
 ```python
-from barangay import search
+from barangay import search_fuzzy
 
-# Simple search
-results = search("Tongmageng, Tawi-Tawi")
-
-# Custom search
-search(
-    "Tongmagen, Tawi-Tawi",
-    n=4,                    # Number of results
-    match_hooks=["municipality", "barangay"],  # Match levels
-    threshold=70.0,         # Minimum similarity (0-100)
-)
-
-# Historical data
-search("Tongmageng", as_of="2025-07-08")
+results = search_fuzzy("Tongmagen, Tawi-Tawi", threshold=60.0, limit=5)
+for r in results:
+    print(f"{r.name} ({r.psgc_id}) — score: {r.score}")
+# Tongmageng (1907005010) — score: 100.0
+# Tonggosong (1907004005) — score: 84.21
+# ...
 ```
 
-### Data Access
+### Address Validation
+
+```python
+from barangay import validate, validate_many
+
+v = validate("Tongmageng, Tawi-Tawi")
+print(v.valid, v.matched_name, v.score)  # True Tongmageng 100.0
+
+results = validate_many(["Tongmageng, Tawi-Tawi", "Nonexistent Place"])
+for r in results:
+    print(f"{r.input!r} -> {'valid' if r.valid else 'invalid'}")
+```
+
+### Export to Pandas
+
+```python
+from barangay import barangays
+
+df = barangays.to_frame()     # pd.DataFrame
+data = barangays.to_dicts()   # List[dict]
+```
+
+### Data Access (Nested & Flat Models)
 
 ```python
 from barangay import barangay, barangay_flat, barangay_extended
@@ -126,22 +191,36 @@ for region in barangay_extended.components:
 brgy = [loc for loc in barangay_flat if loc.name == "Marayos"][0]
 ```
 
+### Search (Dict-based)
+
+```python
+from barangay import search
+
+# Simple search
+results = search("Tongmageng, Tawi-Tawi")
+
+# Custom search
+search(
+    "Tongmagen, Tawi-Tawi",
+    n=4,                    # Number of results
+    match_hooks=["municipality", "barangay"],  # Match levels
+    threshold=70.0,         # Minimum similarity (0-100)
+)
+```
+
 ### Utilities
 
 ```python
-from barangay import sanitize_input, resolve_date, get_available_dates
+from barangay import sanitize_input, resolve_date, get_available_dates, use_version
 
 # Sanitize strings
 cleaned = sanitize_input("City of San Jose", exclude=["city of "])
 # Result: "san jose"
 
-# Resolve to closest available date
-resolved_date, status = resolve_date("2025-07-01", get_available_dates(), "2026-04-13")
-# Result: '2025-07-08'
-
-# Get all available dates
-dates = get_available_dates()
-# ['2026-04-13', '2026-01-13', '2025-08-29', '2025-10-13', '2025-07-08']
+# Switch to historical data
+use_version("2025-07-08")
+brgy = barangays.lookup("1907005010")
+use_version(None)  # back to latest
 ```
 
 📖 **Full API Reference:** [docs/api.md](https://bendlikeabamboo.github.io/barangay/api/)

--- a/barangay/__init__.py
+++ b/barangay/__init__.py
@@ -30,7 +30,7 @@ from barangay.models import BarangayModel  # noqa:E402
 from barangay.fuzz import FuzzBase, create_fuzz_base  # noqa:E402
 
 # Import search functionality
-from barangay.search import search  # noqa:E402
+from barangay.search import search, search_fuzzy  # noqa:E402
 
 # Import utilities
 from barangay.utils import sanitize_input  # noqa:E402
@@ -50,6 +50,18 @@ from barangay.config import (  # noqa:E402
 
 # Import plugin system
 from barangay.plugin_loader import PluginLoader  # noqa:E402
+
+# Import Database API
+from barangay.database import Database, MultipleResultsError  # noqa:E402
+from barangay.models import (  # noqa:E402
+    AdminDivRecord,
+    AdminLevel,
+    PluginInfo,
+    SearchResult,
+    ValidationResult,
+)
+from barangay.validate import validate, validate_many  # noqa:E402
+from barangay.version import use_version, use_plugins  # noqa:E402
 
 # Update available_dates at module import
 available_dates = list(set(get_available_dates() + [current]))
@@ -120,4 +132,5 @@ __all__ = [
     "validate_many",
     "use_version",
     "use_plugins",
+    "MultipleResultsError",
 ]

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,296 @@
 # API Reference
 
-## Main Search Function
+## Database API
 
-### `search()`
+### Database Views
+
+Pre-built views provide direct access to every admin level in the PSGC database. Each view is iterable, supports containment checks, and exposes search, lookup, and export methods.
+
+```python
+from barangay import regions, provinces, municipalities, cities, submunicipalities, barangays, special_geographic_areas
+
+print(regions)     # <PSGC region database: 18 records>
+print(provinces)   # <PSGC province database: 82 records>
+print(barangays)   # <PSGC barangay database: 42010 records>
+```
+
+**Available views:**
+
+| View | Admin Level |
+|------|-------------|
+| `regions` | Region |
+| `provinces` | Province |
+| `municipalities` | Municipality |
+| `cities` | City |
+| `submunicipalities` | Submunicipality |
+| `barangays` | Barangay |
+| `special_geographic_areas` | Special Geographic Area |
+
+#### `.get(name=...)` / `.get(psgc_id=...)`
+
+Look up a single record by name or PSGC ID. Returns an `_EnrichedRecord` or `None`.
+
+```python
+brgy = barangays.get(name="Tongmageng")
+print(brgy)  # <barangay: Tongmageng (1907005010)>
+
+brgy = barangays.get(psgc_id="1907005010")
+print(brgy.region)  # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+```
+
+Raises `MultipleResultsError` when the name matches more than one record. Use `.lookup()` for guaranteed-unique PSGC ID lookups.
+
+#### `.lookup(psgc_id)`
+
+Exact lookup by PSGC ID across all levels. Returns `_EnrichedRecord` or `None`.
+
+```python
+r = barangays.lookup("1907005010")
+print(r)  # <barangay: Tongmageng (1907005010)>
+print(r.to_dict())
+# {'name': 'Tongmageng', 'type': 'barangay', 'psgc_id': '1907005010', ...}
+```
+
+#### `.search_fuzzy(query)`
+
+Fuzzy search scoped to this admin level. Returns `List[SearchResult]`.
+
+```python
+results = barangays.search_fuzzy("Tongmageng, Tawi-Tawi", threshold=60.0, limit=5)
+for r in results:
+    print(f"{r.name} ({r.psgc_id}) — score: {r.score}")
+```
+
+#### `.to_frame()` / `.to_dicts()`
+
+Export records to a pandas DataFrame or list of dicts. Each dict includes resolved hierarchy fields (`region`, `province`, `municipality`, `city`).
+
+```python
+df = barangays.to_frame()
+print(df.columns.tolist())
+# ['name', 'type', 'psgc_id', 'parent_psgc_id', 'nicknames', 'extensions',
+#  'region', 'province', 'municipality', 'city']
+print(df.shape)  # (42010, 10)
+
+data = barangays.to_dicts()
+print(len(data))  # 42010
+```
+
+#### Iteration and containment
+
+```python
+# Iterate
+for region in regions:
+    print(region.name)
+
+# Check membership by PSGC ID
+print("1907005010" in barangays)  # True
+
+# Count
+print(len(barangays))  # 42010
+```
+
+### EnrichedRecord
+
+Every record returned by the Database API is an `_EnrichedRecord` with computed hierarchy properties.
+
+#### Core Fields
+
+| Property | Type | Description |
+|-----------|------|-------------|
+| `.name` | `str` | Name of the administrative division |
+| `.type` | `AdminLevel` | Admin level enum (`"region"`, `"province"`, `"city"`, `"municipality"`, `"barangay"`, etc.) |
+| `.psgc_id` | `str` | PSGC identifier |
+| `.parent_psgc_id` | `str` | Parent PSGC identifier |
+
+#### Hierarchy Properties
+
+| Property | Type | Description |
+|-----------|------|-------------|
+| `.region` | `str \| None` | Name of the containing region |
+| `.province` | `str \| None` | Name of the containing province |
+| `.municipality` | `str \| None` | Name of the containing municipality |
+| `.city` | `str \| None` | Name of the containing city |
+| `.parent` | `_EnrichedRecord \| None` | Direct parent record |
+| `.children` | `list[_EnrichedRecord]` | Direct child records |
+| `.ancestors` | `list[_EnrichedRecord]` | All ancestors from parent to root |
+
+#### Example
+
+```python
+brgy = barangays.get(name="Tongmageng")
+print(brgy.region)      # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)    # Tawi-Tawi
+print(brgy.municipality)  # Sitangkai
+print(brgy.parent)      # <municipality: Sitangkai (1907005000)>
+
+for a in brgy.ancestors:
+    print(repr(a))
+# <municipality: Sitangkai (1907005000)>
+# <province: Tawi-Tawi (1907000000)>
+# <region: Bangsamoro Autonomous Region In Muslim Mindanao (BARMM) (1900000000)>
+```
+
+#### `.to_dict()`
+
+Serialize to a dict including resolved hierarchy fields:
+
+```python
+d = brgy.to_dict()
+# {'name': 'Tongmageng', 'type': 'barangay', 'psgc_id': '1907005010',
+#  'parent_psgc_id': '1907005000', 'nicknames': None, 'extensions': [],
+#  'region': 'Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)',
+#  'province': 'Tawi-Tawi', 'municipality': 'Sitangkai', 'city': None}
+```
+
+### `search_fuzzy()`
+
+Typed fuzzy search returning `SearchResult` objects with rich attributes.
+
+```python
+from barangay import search_fuzzy
+
+results = search_fuzzy("Tongmageng, Tawi-Tawi", threshold=60.0, limit=5)
+for r in results:
+    print(f"{r.name} ({r.psgc_id}) — score: {r.score}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | — | Search string |
+| `level` | `AdminLevel \| None` | `None` | Filter to a specific admin level |
+| `threshold` | `float` | `60.0` | Minimum similarity score (0-100) |
+| `limit` | `int` | `5` | Maximum number of results |
+| `as_of` | `str \| None` | `None` | Historical date (YYYY-MM-DD) |
+
+**Returns:** `List[SearchResult]`
+
+**SearchResult properties:**
+
+| Property | Type | Description |
+|-----------|------|-------------|
+| `.name` | `str` | Matched record name |
+| `.psgc_id` | `str` | Matched record PSGC ID |
+| `.score` | `float` | Similarity score (0-100) |
+| `.match_type` | `str` | Match pattern (e.g. `"province+municipality+barangay"`) |
+| `.record` | `AdminDivRecord` | Underlying record |
+| `.enriched` | `_EnrichedRecord` | Enriched view (requires hierarchy index) |
+
+### `validate()` / `validate_many()`
+
+Validate address strings against the PSGC masterlist using fuzzy matching.
+
+```python
+from barangay import validate, validate_many
+
+v = validate("Tongmageng, Tawi-Tawi")
+print(v.valid)          # True
+print(v.matched_name)   # Tongmageng
+print(v.matched_psgc_id) # 1907005010
+print(v.score)          # 100.0
+
+results = validate_many([
+    "Tongmageng, Tawi-Tawi",
+    "Brgy 291, City of Manila",
+    "Nonexistent Place",
+])
+for r in results:
+    print(f"{r.input!r} -> {'valid' if r.valid else 'invalid'}")
+# 'Tongmageng, Tawi-Tawi' -> valid
+# 'Brgy 291, City of Manila' -> invalid
+# 'Nonexistent Place' -> invalid
+```
+
+**`validate()` parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `address` | `str` | — | Address string to validate |
+| `threshold` | `float` | `95.0` | Minimum score for a valid match |
+| `as_of` | `str \| None` | `None` | Historical date |
+
+**Returns:** `ValidationResult`
+
+**ValidationResult properties:**
+
+| Property | Type | Description |
+|-----------|------|-------------|
+| `.input` | `str` | Original input string |
+| `.valid` | `bool` | Whether a match was found above threshold |
+| `.matched_name` | `str \| None` | Name of the matched record |
+| `.matched_psgc_id` | `str \| None` | PSGC ID of the matched record |
+| `.matched_record` | `AdminDivRecord \| None` | Full matched record |
+| `.score` | `float \| None` | Confidence score |
+
+**`validate_many()`** takes a `list[str]` of addresses and returns `list[ValidationResult]`.
+
+### `use_version()` / `use_plugins()`
+
+Switch the global Database to a different data version or enable plugins.
+
+```python
+import barangay
+
+# Switch to historical data
+barangay.use_version("2025-07-08")
+brgy = barangay.barangays.lookup("1907005010")
+barangay.use_version(None)  # back to latest
+
+# Enable plugins
+barangay.use_plugins(["population"], levels=[barangay.AdminLevel.CITY])
+```
+
+**`use_version()`** invalidates the cache and triggers a reload on next access.
+
+**`use_plugins()`** enables plugins on the global Database singleton.
+
+### `Database` Class
+
+The central data access point, implemented as a singleton. You typically use the module-level views instead of instantiating directly.
+
+```python
+from barangay import Database
+
+db = Database()  # returns the singleton
+print(db.barangays)  # <PSGC barangay database: 42010 records>
+print(db.all_records)  # <PSGC all database: 43363 records>
+```
+
+**Properties:** `.regions`, `.provinces`, `.municipalities`, `.cities`, `.submunicipalities`, `.barangays`, `.special_geographic_areas`, `.all_records`
+
+**Methods:** `.use_plugins()`, `.available_plugins()`, `.active_plugins()`
+
+### `AdminLevel`
+
+Enum of administrative division types.
+
+```python
+from barangay import AdminLevel
+
+print(AdminLevel.REGION)     # AdminLevel.REGION
+print(AdminLevel.REGION.value)  # 'region'
+
+# All values: country, region, province, city, municipality, submunicipality, barangay, special_geographic_area
+```
+
+### `MultipleResultsError`
+
+Raised when `.get(name=...)` matches multiple records.
+
+```python
+from barangay import barangays, MultipleResultsError
+
+try:
+    result = barangays.get(name="San Roque")  # many barangays named San Roque
+except MultipleResultsError as e:
+    print(e)  # Name 'San Roque' matched 42 records. Use psgc_id for exact lookup, or iterate.
+```
+
+---
+
+## Search (Dict-based)
 
 Search for barangays using fuzzy string matching.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@
       },
       {
         "@type": "HowToStep",
-        "text": "Search for a barangay: from barangay import search; search('Tongmageng, Tawi-Tawi')"
+        "text": "Search for a barangay: from barangay import search_fuzzy; search_fuzzy('Tongmageng, Tawi-Tawi')"
       }
     ]
   }
@@ -54,8 +54,11 @@
 ## Features
 
 - **Bundled PSGC Dataset**: Native access to PSGC data, no database or API calls needed
+- **Hierarchy Traversal**: Navigate parent, children, and ancestors of any admin division
+- **Direct Pandas Export**: `to_frame()` and `to_dicts()` for immediate DataFrame access
+- **Address Validation**: `validate()` and `validate_many()` for automated address checking
+- **Fuzzy Search**: Fast, customizable fuzzy matching with typed `SearchResult` objects
 - **Historical PSGC Data**: On-demand access to previous PSGC releases by date
-- **Fuzzy Search**: Fast, customizable fuzzy matching
 - **Multiple Data Models**: Basic (nested), Extended (recursive), and Flat (list)
 - **Plug-in System**: Enrich PSGC data with custom extensions via plug-ins (CSV, JSON, Parquet)
 
@@ -67,86 +70,60 @@ pip install barangay
 
 ## Quick Start
 
-### Basic Search
+```python
+from barangay import barangays, search_fuzzy
+
+# Browse all barangays
+print(barangays)  # <PSGC barangay database: 42010 records>
+
+# Get a specific barangay and traverse its hierarchy
+brgy = barangays.get(name="Tongmageng")
+print(brgy.region)    # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)  # Tawi-Tawi
+print(brgy.psgc_id)   # 1907005010
+
+# Fuzzy search with typed results
+for r in search_fuzzy("Tongmagen, Tawi-Tawi"):
+    print(f"{r.name} ({r.psgc_id}) — score: {r.score}")
+```
+
+## Explore Data
+
+### Pandas Export
 
 ```python
-from barangay import search
+from barangay import barangays
 
-results = search("Tongmageng, Tawi-Tawi")
-top_result = results[0]
-print(f"Barangay Name: {top_result["barangay"]}")
-print(f"PSGC ID: {top_result["psgc_id"]}")
+df = barangays.to_frame()
+print(df.columns.tolist())
+# ['name', 'type', 'psgc_id', 'parent_psgc_id', 'nicknames', 'extensions',
+#  'region', 'province', 'municipality', 'city']
+print(df.shape)  # (42010, 10)
 ```
 
-Output:
-```txt
-Barangay Name: Tongmageng
-PSGC ID: 1907005010
-```
-### Access Data Directly
+### Hierarchy Traversal
 
 ```python
-from barangay import barangay
+brgy = barangays.get(name="Tongmageng")
+print(brgy.parent)     # <municipality: Sitangkai (1907005000)>
+print(brgy.ancestors)  # [municipality, province, region]
 
-ncr: dict = barangay["National Capital Region (NCR)"]
-print(f"NCR Components: \n\t{'\n\t'.join(list(ncr.keys()))}")
-
-city_of_manila_municipalities: dict = ncr["City of Manila"]
-print(
-    "City of Manila Municipalities: \n\t"
-    f"{'\n\t'.join(list(city_of_manila_municipalities.keys()))}"
-)
-
-binondo_barangays: list = city_of_manila_municipalities["Binondo"]
-print(f"Binondo Barangays: \n\t{'\n\t'.join(binondo_barangays)}")
+manila = cities.get(name="City of Manila")
+for child in manila.children[:3]:
+    print(child)  # <submunicipality: Tondo I/II ...>, <submunicipality: Binondo ...>, ...
 ```
 
-Output:
-```txt
-NCR Components: 
-	City of Manila
-	City of Caloocan
-	City of Las Piñas
-	City of Makati
-	City of Malabon
-	City of Mandaluyong
-	City of Marikina
-	City of Muntinlupa
-	City of Navotas
-	City of Parañaque
-	City of Pasig
-	City of San Juan
-	City of Taguig
-	City of Valenzuela
-	Pasay City
-	Quezon City
-	Pateros
-City of Manila Municipalities: 
-	Binondo
-	Ermita
-	Intramuros
-	Malate
-	Paco
-	Pandacan
-	Port Area
-	Quiapo
-	Sampaloc
-	San Miguel
-	San Nicolas
-	Santa Ana
-	Santa Cruz
-	Tondo I/II
-Binondo Barangays: 
-	Barangay 291
-	Barangay 290
-	Barangay 293
-	Barangay 294
-	Barangay 292
-	Barangay 289
-	Barangay 296
-	Barangay 287
-	Barangay 288
-	Barangay 295
+### Address Validation
+
+```python
+from barangay import validate, validate_many
+
+v = validate("Tongmageng, Tawi-Tawi")
+print(v.valid, v.matched_name, v.score)  # True Tongmageng 100.0
+
+results = validate_many(["Tongmageng, Tawi-Tawi", "Nonexistent Place"])
+for r in results:
+    print(f"{r.input!r} -> {'valid' if r.valid else 'invalid'}")
 ```
 
 ### CLI Usage
@@ -201,6 +178,7 @@ Current data version: [**2026-04-13** (April 13 2026 PSGC masterlist)](https://p
 
 ## Documentation
 
+- [Getting Started](tutorials/database_api.md) — Database API tutorial
 - [API Reference](api.md)
 - [CLI Reference](cli.md)
 - [Configuration](configuration.md)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13,26 +13,27 @@ Requires Python 3.13+.
 ## Quick Start
 
 ```python
-from barangay import search
+from barangay import barangays, search_fuzzy
 
-results = search("Tongmageng, Tawi-Tawi")
-top_result = results[0]
-print(f"Barangay Name: {top_result['barangay']}")
-print(f"PSGC ID: {top_result['psgc_id']}")
-```
+print(barangays)  # <PSGC barangay database: 42010 records>
 
-Output:
+brgy = barangays.get(name="Tongmageng")
+print(brgy.region)    # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)  # Tawi-Tawi
+print(brgy.psgc_id)   # 1907005010
 
-```txt
-Barangay Name: Tongmageng
-PSGC ID: 1907005010
+for r in search_fuzzy("Tongmagen, Tawi-Tawi"):
+    print(f"{r.name} ({r.psgc_id}) — score: {r.score}")
 ```
 
 ## Features
 
 - **Bundled PSGC Dataset**: Native access to PSGC data, no database or API calls needed
+- **Hierarchy Traversal**: Navigate parent, children, and ancestors of any admin division
+- **Direct Pandas Export**: `to_frame()` and `to_dicts()` for immediate DataFrame access
+- **Address Validation**: `validate()` and `validate_many()` for automated address checking
+- **Fuzzy Search**: Fast, customizable fuzzy matching with typed `SearchResult` objects
 - **Historical PSGC Data**: On-demand access to previous PSGC releases by date
-- **Fuzzy Search**: Fast, customizable fuzzy matching for unstandardized addresses
 - **Multiple Data Models**: Basic (nested), Extended (recursive), and Flat (list)
 - **Command Line Interface**: Full CLI for search, export, validation, batch operations
 - **Smart Caching**: Automatic local caching for faster subsequent loads
@@ -40,7 +41,98 @@ PSGC ID: 1907005010
 
 ---
 
-## API Reference
+## Database API
+
+### Database Views
+
+Pre-built views for each admin level:
+
+```python
+from barangay import regions, provinces, municipalities, cities, submunicipalities, barangays, special_geographic_areas
+
+print(regions)     # <PSGC region database: 18 records>
+print(provinces)   # <PSGC province database: 82 records>
+print(barangays)   # <PSGC barangay database: 42010 records>
+```
+
+Each view supports `.get(name=...)`, `.get(psgc_id=...)`, `.lookup(psgc_id)`, `.search_fuzzy(query)`, `.to_frame()`, `.to_dicts()`, iteration, `len()`, and `in` (by PSGC ID).
+
+### Lookup
+
+```python
+brgy = barangays.get(name="Tongmageng")      # by name (raises MultipleResultsError if ambiguous)
+brgy = barangays.lookup("1907005010")        # by PSGC ID (always unique)
+```
+
+### Hierarchy Traversal
+
+```python
+brgy = barangays.get(name="Tongmageng")
+print(brgy.region)       # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)     # Tawi-Tawi
+print(brgy.municipality)  # Sitangkai
+print(brgy.parent)       # <municipality: Sitangkai (1907005000)>
+print(brgy.ancestors)    # [municipality, province, region]
+print(brgy.children)      # direct children
+
+d = brgy.to_dict()  # includes region, province, municipality, city fields
+```
+
+### Fuzzy Search
+
+```python
+from barangay import search_fuzzy
+
+results = search_fuzzy("query", level=None, threshold=60.0, limit=5, as_of=None)
+for r in results:
+    print(r.name, r.psgc_id, r.score, r.match_type)
+```
+
+Returns `List[SearchResult]` with properties: `.name`, `.psgc_id`, `.score`, `.match_type`, `.record`, `.enriched`.
+
+### Validation
+
+```python
+from barangay import validate, validate_many
+
+v = validate("Tongmageng, Tawi-Tawi")  # default threshold 95.0
+print(v.valid, v.matched_name, v.matched_psgc_id, v.score)
+# True Tongmageng 1907005010 100.0
+
+results = validate_many(["addr1", "addr2"])
+for r in results:
+    print(r.valid, r.matched_name, r.score)
+```
+
+### Version Switching
+
+```python
+import barangay
+
+barangay.use_version("2025-07-08")
+brgy = barangay.barangays.lookup("1907005010")
+barangay.use_version(None)  # back to latest
+```
+
+### Plugins
+
+```python
+import barangay
+
+barangay.use_plugins(["population"], levels=[barangay.AdminLevel.CITY])
+```
+
+### AdminLevel Enum
+
+Values: `country`, `region`, `province`, `city`, `municipality`, `submunicipality`, `barangay`, `special_geographic_area`.
+
+### MultipleResultsError
+
+Raised by `.get(name=...)` when the name matches multiple records. Use `.lookup(psgc_id)` for unique lookups.
+
+---
+
+## Legacy API
 
 ### search()
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -13,31 +13,127 @@ Requires Python 3.13+.
 ## Quick Start
 
 ```python
-from barangay import search
+from barangay import barangays, search_fuzzy
 
-results = search("Tongmageng, Tawi-Tawi")
-print(results[0]["barangay"])  # 'Tongmageng'
-print(results[0]["psgc_id"])   # '1907005010'
+print(barangays)  # <PSGC barangay database: 42010 records>
+
+brgy = barangays.get(name="Tongmageng")
+print(brgy.region)    # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)  # Tawi-Tawi
+print(brgy.psgc_id)   # 1907005010
+
+for r in search_fuzzy("Tongmagen, Tawi-Tawi"):
+    print(f"{r.name} ({r.psgc_id}) — score: {r.score}")
 ```
 
 ## Key Features
 
 - **Fuzzy search** — handles misspellings and unstandardized addresses using rapidfuzz
 - **Bundled data** — all 42,011 barangays, 1,488 municipalities, 146 cities, 82 provinces, 17 regions included offline
+- **Hierarchy traversal** — navigate parent, children, and ancestors of any admin division
+- **Pandas export** — `to_frame()` and `to_dicts()` for immediate DataFrame access
+- **Address validation** — `validate()` and `validate_many()` with configurable thresholds
 - **Historical PSGC** — access previous masterlist releases by date (2023–2026)
 - **Three data models** — nested (dict-like), flat (list), extended (recursive with metadata)
 - **CLI included** — search, export, validate, batch operations
 - **Smart caching** — automatic local caching for subsequent loads
 - **Plug-in system** — enrich PSGC data with custom extensions (CSV, JSON, Parquet), built-in and remote plugins supported
 
-## API Overview
+## Database API
 
-### Search
+### Views
+
+```python
+from barangay import regions, provinces, municipalities, cities, submunicipalities, barangays, special_geographic_areas
+
+# Iterate, count, check membership
+print(len(barangays))  # 42010
+print("1907005010" in barangays)  # True
+for region in regions:
+    print(region.name)
+```
+
+### Lookup
+
+```python
+# By name (raises MultipleResultsError if ambiguous)
+brgy = barangays.get(name="Tongmageng")
+
+# By PSGC ID (always unique)
+brgy = barangays.lookup("1907005010")
+```
+
+### Hierarchy
+
+```python
+brgy = barangays.get(name="Tongmageng")
+print(brgy.region)       # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)     # Tawi-Tawi
+print(brgy.municipality)  # Sitangkai
+print(brgy.parent)       # <municipality: Sitangkai (1907005000)>
+print(brgy.ancestors)    # [municipality, province, region]
+print(brgy.children)      # direct children
+
+# Serialize with hierarchy fields
+d = brgy.to_dict()
+# {'name': 'Tongmageng', 'psgc_id': '1907005010', 'region': '...', 'province': 'Tawi-Tawi', ...}
+```
+
+### Export
+
+```python
+df = barangays.to_frame()     # pd.DataFrame with region, province, municipality, city columns
+data = barangays.to_dicts()   # List[dict]
+```
+
+### Fuzzy Search
+
+```python
+from barangay import search_fuzzy
+
+results = search_fuzzy("query", level=None, threshold=60.0, limit=5, as_of=None)
+for r in results:
+    print(r.name, r.psgc_id, r.score, r.match_type)
+```
+
+### Validation
+
+```python
+from barangay import validate, validate_many
+
+v = validate("Tongmageng, Tawi-Tawi")  # default threshold 95.0
+print(v.valid, v.matched_name, v.score)  # True Tongmageng 100.0
+
+results = validate_many(["addr1", "addr2"])
+```
+
+### Version Switching
+
+```python
+import barangay
+
+barangay.use_version("2025-07-08")
+brgy = barangay.barangays.lookup("1907005010")
+barangay.use_version(None)  # back to latest
+```
+
+### Plugins
+
+```python
+import barangay
+
+barangay.use_plugins(["population"], levels=[barangay.AdminLevel.CITY])
+```
+
+## Legacy API
+
+### Search (dict-based)
 
 ```python
 from barangay import search
 
 results = search("query", n=5, threshold=60.0, match_hooks=["province", "municipality", "barangay"], as_of=None)
+# Returns List[dict] with keys: barangay, province_or_huc, municipality_or_city, psgc_id, ...
 ```
 
 ### Data Access

--- a/docs/tutorials/address_validation.md
+++ b/docs/tutorials/address_validation.md
@@ -19,7 +19,56 @@ The `barangay` package solves this by matching addresses against the official Ph
 pip install barangay
 ```
 
-## Basic Validation
+## Using `validate()`
+
+The `validate()` function provides a simple interface for address validation with a high-confidence default threshold of 95.0:
+
+```python
+from barangay import validate
+
+v = validate("Tongmageng, Tawi-Tawi")
+print(v.valid, v.matched_name, v.score)  # True Tongmageng 100.0
+```
+
+For addresses that use abbreviations or non-standard formats, lower the threshold:
+
+```python
+v = validate("Brgy 291, City of Manila", threshold=80.0)
+print(v.valid, v.matched_name, v.score)  # True Barangay 291 88.24
+```
+
+### Batch Validation with `validate_many()`
+
+Validate multiple addresses at once:
+
+```python
+from barangay import validate_many
+
+results = validate_many([
+    "Tongmageng, Tawi-Tawi",
+    "Brgy 291, City of Manila",
+    "Nonexistent Place",
+])
+for r in results:
+    status = "valid" if r.valid else "invalid"
+    print(f"{r.input!r} -> {status}")
+# 'Tongmageng, Tawi-Tawi' -> valid
+# 'Brgy 291, City of Manila' -> invalid
+# 'Nonexistent Place' -> invalid
+```
+
+### ValidationResult Properties
+
+| Property | Type | Description |
+|-----------|------|-------------|
+| `.input` | `str` | Original input string |
+| `.valid` | `bool` | Whether a match was found above threshold |
+| `.matched_name` | `str \| None` | Name of the matched record |
+| `.matched_psgc_id` | `str \| None` | PSGC ID of the matched record |
+| `.matched_record` | `AdminDivRecord \| None` | Full matched record |
+| `.score` | `float \| None` | Confidence score |
+
+## Using `search()` with Threshold
 
 Use the `search()` function with a high threshold to validate addresses:
 

--- a/docs/tutorials/bulk_barangay_lookup.md
+++ b/docs/tutorials/bulk_barangay_lookup.md
@@ -6,6 +6,9 @@ Perform bulk lookups and searches across the complete PSGC dataset of 42,011 bar
 
 When cleaning large datasets of Philippine addresses or geographic references, you need efficient batch processing. The `barangay` package provides:
 
+- Database views with `to_frame()` and `to_dicts()` for direct export
+- `search_fuzzy()` for typed fuzzy search results
+- `validate_many()` for batch address validation
 - Pre-computed fuzzy matching via `FuzzBase` for fast repeated lookups
 - CLI batch commands for file-based processing
 - Direct access to flat data models for filtering and joins
@@ -16,7 +19,54 @@ When cleaning large datasets of Philippine addresses or geographic references, y
 pip install barangay
 ```
 
-## Method 1: Python Batch Search (Recommended)
+## Method 1: Database Views (Recommended)
+
+Export data directly from database views for the most common use cases:
+
+```python
+from barangay import barangays
+
+# Export all barangays to pandas DataFrame
+df = barangays.to_frame()
+print(df.shape)  # (42010, 10)
+print(df.columns.tolist())
+# ['name', 'type', 'psgc_id', 'parent_psgc_id', 'nicknames', 'extensions',
+#  'region', 'province', 'municipality', 'city']
+
+# Export as list of dicts
+data = barangays.to_dicts()
+print(len(data))  # 42010
+```
+
+### Fuzzy Search on a View
+
+Search within a specific admin level:
+
+```python
+results = barangays.search_fuzzy("Tongmageng, Tawi-Tawi", threshold=60.0, limit=5)
+for r in results:
+    print(f"{r.name} ({r.psgc_id}) — score: {r.score}")
+```
+
+### Batch Validation
+
+```python
+from barangay import validate_many
+
+addresses = [
+    "Tongmageng, Tawi-Tawi",
+    "Barangay 291, Manila",
+    "Poblacion, Cebu City",
+]
+results = validate_many(addresses, threshold=80.0)
+for r in results:
+    if r.valid:
+        print(f"{r.input!r} -> {r.matched_name} ({r.matched_psgc_id})")
+    else:
+        print(f"{r.input!r} -> NOT FOUND")
+```
+
+## Method 2: Python Batch Search with FuzzBase
 
 Reuse a `FuzzBase` instance to avoid reloading data on every search:
 
@@ -72,7 +122,7 @@ with open("results.json", "w") as f:
     json.dump(output, f, indent=2)
 ```
 
-## Method 2: CLI Batch Search
+## Method 3: CLI Batch Search
 
 Create a file with one query per line:
 
@@ -82,7 +132,7 @@ barangay batch batch-search queries.txt --limit 5 --output results.json
 
 This reads `queries.txt` and writes matched results to `results.json`.
 
-## Method 3: Direct Data Filtering
+## Method 4: Direct Data Filtering
 
 For exact or prefix matching, filter the flat data model directly:
 
@@ -105,7 +155,7 @@ pangasinan_barangays = [
 print(f"Pangasinan (Region I) has {len(pangasinan_barangays)} barangays")
 ```
 
-## Method 4: Export Entire Dataset
+## Method 5: Export Entire Dataset
 
 Use the CLI to export all data for offline processing:
 
@@ -129,8 +179,10 @@ with open("all_barangays.json", "w") as f:
 
 | Approach | Speed | Use Case |
 |----------|-------|----------|
-| `FuzzBase` + `search()` | ~25-80ms/query | Fuzzy matching with typos |
+| `to_frame()` / `to_dicts()` | Fastest | Full dataset export |
 | Filter `barangay_flat` | <1ms/query | Exact or prefix matching |
+| `FuzzBase` + `search()` | ~25-80ms/query | Fuzzy matching with typos |
+| `validate_many()` | ~25-80ms/query | Batch address validation |
 | CLI `batch-search` | Batch optimized | File-based processing |
 | `export` + external tools | Fastest | Full dataset export |
 
@@ -151,6 +203,7 @@ barangay batch batch-search queries.txt --as-of "2025-07-08" --output historical
 
 ## Next Steps
 
+- [Getting Started](database_api.md) — Database API overview
 - [Address Validation](address_validation.md) — validating individual addresses
-- [API Reference](../api.md) — `search()` and `FuzzBase` documentation
+- [API Reference](../api.md) — `search()`, `search_fuzzy()`, and `FuzzBase` documentation
 - [CLI Reference](../cli.md) — batch command options

--- a/docs/tutorials/database_api.md
+++ b/docs/tutorials/database_api.md
@@ -1,0 +1,160 @@
+# Getting Started with the Database API
+
+A quick walkthrough of the `barangay` Database API for browsing, searching, validating, and exporting Philippine geographic data.
+
+## Installation
+
+```bash
+pip install barangay
+```
+
+## 1. Browse Administrative Levels
+
+Pre-built views give you direct access to every admin level in the PSGC database:
+
+```python
+from barangay import regions, provinces, municipalities, cities, barangays
+
+print(regions)     # <PSGC region database: 18 records>
+print(provinces)   # <PSGC province database: 82 records>
+print(barangays)   # <PSGC barangay database: 42010 records>
+```
+
+Each view supports iteration, containment checks, and counting:
+
+```python
+print(len(barangays))          # 42010
+print("1907005010" in barangays)  # True
+
+for region in regions:
+    print(region.name)
+# Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+# Cordillera Administrative Region (CAR)
+# MIMAROPA Region
+# ...
+```
+
+## 2. Look Up a Record
+
+Look up a single record by name or PSGC ID:
+
+```python
+# By name
+brgy = barangays.get(name="Tongmageng")
+print(brgy)  # <barangay: Tongmageng (1907005010)>
+
+# By PSGC ID (always unique)
+brgy = barangays.lookup("1907005010")
+print(brgy.name)  # Tongmageng
+```
+
+If a name matches multiple records, `get()` raises `MultipleResultsError`. Use `lookup()` with a PSGC ID for guaranteed-unique lookups.
+
+## 3. Traverse the Hierarchy
+
+Each record knows its position in the administrative hierarchy:
+
+```python
+brgy = barangays.get(name="Tongmageng")
+
+print(brgy.region)       # Bangsamoro Autonomous Region In Muslim Mindanao (BARMM)
+print(brgy.province)     # Tawi-Tawi
+print(brgy.municipality)  # Sitangkai
+print(brgy.parent)       # <municipality: Sitangkai (1907005000)>
+
+for ancestor in brgy.ancestors:
+    print(repr(ancestor))
+# <municipality: Sitangkai (1907005000)>
+# <province: Tawi-Tawi (1907000000)>
+# <region: Bangsamoro Autonomous Region In Muslim Mindanao (BARMM) (1900000000)>
+```
+
+Navigate downward with `.children`:
+
+```python
+manila = cities.get(name="City of Manila")
+for child in manila.children[:3]:
+    print(repr(child))
+# <submunicipality: Tondo I/II (1380601000)>
+# <submunicipality: Binondo (1380602000)>
+# <submunicipality: Quiapo (1380603000)>
+```
+
+## 4. Export to Pandas
+
+Export any view directly to a DataFrame or list of dicts:
+
+```python
+df = barangays.to_frame()
+print(df.columns.tolist())
+# ['name', 'type', 'psgc_id', 'parent_psgc_id', 'nicknames', 'extensions',
+#  'region', 'province', 'municipality', 'city']
+print(df.shape)  # (42010, 10)
+
+data = barangays.to_dicts()
+print(len(data))  # 42010
+print(data[0])
+# {'name': 'Arco', 'type': 'barangay', 'psgc_id': '1900702001', ...}
+```
+
+Each record includes resolved hierarchy fields (`region`, `province`, `municipality`, `city`) for immediate use in analysis.
+
+## 5. Fuzzy Search
+
+Search with fuzzy matching, returning typed `SearchResult` objects:
+
+```python
+from barangay import search_fuzzy
+
+results = search_fuzzy("Tongmagen, Tawi-Tawi", threshold=60.0, limit=5)
+for r in results:
+    print(f"{r.name} ({r.psgc_id}) — score: {r.score}")
+# Tongmageng (1907005010) — score: 100.0
+# Tonggosong (1907004005) — score: 84.21
+# Tongbangkaw (1907007042) — score: 82.05
+# Tongusong (1907005012) — score: 81.08
+# Tongehat (1907011014) — score: 77.78
+```
+
+Each result exposes `.name`, `.psgc_id`, `.score`, and `.match_type`.
+
+## 6. Validate Addresses
+
+Validate addresses against the PSGC masterlist with a high-confidence threshold:
+
+```python
+from barangay import validate, validate_many
+
+v = validate("Tongmageng, Tawi-Tawi")
+print(v.valid, v.matched_name, v.score)  # True Tongmageng 100.0
+```
+
+Validate multiple addresses at once:
+
+```python
+results = validate_many([
+    "Tongmageng, Tawi-Tawi",
+    "Brgy 291, City of Manila",
+    "Nonexistent Place",
+])
+for r in results:
+    status = "valid" if r.valid else "invalid"
+    print(f"{r.input!r} -> {status}")
+# 'Tongmageng, Tawi-Tawi' -> valid
+# 'Brgy 291, City of Manila' -> invalid
+# 'Nonexistent Place' -> invalid
+```
+
+The default threshold is 95.0. Lower it for more lenient matching:
+
+```python
+v = validate("Brgy 291, City of Manila", threshold=80.0)
+print(v.valid, v.score)  # True 88.24
+```
+
+## Next Steps
+
+- [API Reference](../api.md) — full documentation of all Database API methods
+- [Address Validation](address_validation.md) — deep dive into validation techniques
+- [Bulk Barangay Lookup](bulk_barangay_lookup.md) — batch processing at scale
+- [Plugins](../plugins/index.md) — enriching data with plugins

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Overview: data_models/overview.md
       - Python: data_models/python.md
   - Tutorials:
+      - Getting Started: tutorials/database_api.md
       - Address Validation: tutorials/address_validation.md
       - Bulk Barangay Lookup: tutorials/bulk_barangay_lookup.md
   - Plugins:


### PR DESCRIPTION
## Summary

- Rewrite README quick start, features table, and Python API examples to showcase the new Database API (views, hierarchy traversal, Pandas export, `search_fuzzy`, `validate`/`validate_many`)
- Add full Database API reference to `docs/api.md` covering all views, `EnrichedRecord` properties, lookup/search/export methods, validation, version switching, and plugins
- Create new **Getting Started** tutorial (`docs/tutorials/database_api.md`) with step-by-step walkthrough
- Update `address_validation` and `bulk_barangay_lookup` tutorials with Database API methods
- Refresh LLM context files (`llms.txt`, `llms-full.txt`) with new API surface
- Register new tutorial in `mkdocs.yml` nav
- Export `MultipleResultsError` in `__all__` to fix ruff lint

## Files changed (10)

| File | Change |
|------|--------|
| `README.md` | New quick start, feature table, API examples |
| `barangay/__init__.py` | Add `MultipleResultsError` to `__all__` |
| `docs/api.md` | Full Database API reference (+288 lines) |
| `docs/index.md` | Updated features, quick start, nav links |
| `docs/llms-full.txt` | Database API context for LLMs |
| `docs/llms.txt` | Concise Database API overview for LLMs |
| `docs/tutorials/address_validation.md` | `validate()`/`validate_many()` docs |
| `docs/tutorials/bulk_barangay_lookup.md` | Database views, fuzzy search, batch validation |
| `docs/tutorials/database_api.md` | New getting started tutorial |
| `mkdocs.yml` | Register tutorial in nav |