### PR TITLE
deprecate: add deprecation warnings and docs for legacy APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ brgy = [loc for loc in barangay_flat if loc.name == "Marayos"][0]
 
 ### Search (Dict-based)
 
+> **Deprecated:** The `search()` function returns raw dicts and will be removed in 2027.X.X.X. Use [`search_fuzzy()`](#fuzzy-search) instead for typed results.
+
 ```python
 from barangay import search
 
@@ -261,6 +263,8 @@ Three data structures are available. Choose based on your use case:
 | [`barangay_flat`](https://bendlikeabamboo.github.io/barangay/api/#barangay_flat-listadmindivflat) | Search & filtering | Flat list with parent references |
 
 **Note:** Pydantic models (`barangay`, `barangay_extended`, `barangay_flat`) are recommended. Dict versions (`BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT`) are available for backward compatibility.
+
+> **Deprecation:** `BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT` dict aliases will be removed in 2027.X.X.X. Use the Database API instead (e.g. `from barangay import barangays; barangays.get(name="Tongmageng")`).
 
 ---
 

--- a/barangay/__init__.py
+++ b/barangay/__init__.py
@@ -1,5 +1,6 @@
 """Barangay data package for Philippine administrative divisions."""
 
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -78,11 +79,34 @@ special_geographic_areas = _db.special_geographic_areas
 
 # Backward compatibility aliases
 # Note: These convert Pydantic models to dicts at module import time.
-# For better performance, use the 'barangay', 'barangay_extended', or 'barangay_flat'
-# models directly instead of these dict aliases.
+# DEPRECATED: These dict aliases will be removed in 2027.X.X.X.
+# Use the Database API instead (e.g. `from barangay import barangays; barangays.get(name="Tongmageng")`).
 
+warnings.warn(
+    "BARANGAY is deprecated and will be removed in 2027.X.X.X. "
+    "Use the Database API instead: "
+    "from barangay import barangays; barangays.get(name='Tongmageng')",
+    DeprecationWarning,
+    stacklevel=2,
+)
 BARANGAY: dict[str, Any] = barangay.model_dump()
+
+warnings.warn(
+    "BARANGAY_EXTENDED is deprecated and will be removed in 2027.X.X.X. "
+    "Use the Database API instead: hierarchy traversal via .parent, .ancestors, .children "
+    "(e.g. from barangay import barangays; rec = barangays.get(name='Tongmageng'); rec.parent)",
+    DeprecationWarning,
+    stacklevel=2,
+)
 BARANGAY_EXTENDED: dict[str, Any] = barangay_extended.model_dump()
+
+warnings.warn(
+    "BARANGAY_FLAT is deprecated and will be removed in 2027.X.X.X. "
+    "Use the Database API instead: to_frame(), to_dicts(), iteration "
+    "(e.g. from barangay import barangays; barangays.to_frame())",
+    DeprecationWarning,
+    stacklevel=2,
+)
 BARANGAY_FLAT: list[dict[str, Any]] = [x.model_dump() for x in barangay_flat]
 
 __all__ = [

--- a/barangay/models.py
+++ b/barangay/models.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+import warnings
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, RootModel
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    RootModel,
+    model_validator,
+)
 from typing import TYPE_CHECKING, Any, Literal, Optional, List
 
 if TYPE_CHECKING:
@@ -11,6 +19,10 @@ if TYPE_CHECKING:
 
 class BarangayModel(BaseModel):
     """Model representing a barangay with its location details.
+
+    .. deprecated::
+        BarangayModel is deprecated and will be removed in 2027.X.X.X.
+        Use AdminDivRecord (via the Database API) instead.
 
     Attributes:
         barangay: Name of the barangay.
@@ -23,6 +35,17 @@ class BarangayModel(BaseModel):
     province_or_huc: str
     municipality_or_city: str
     psgc_id: str
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _deprecation_warning(cls, values, handler, info):
+        warnings.warn(
+            "BarangayModel is deprecated and will be removed in 2027.X.X.X. "
+            "Use AdminDivRecord (via the Database API) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return handler(values)
 
 
 class PluginExtensionMetadata(BaseModel):

--- a/barangay/search.py
+++ b/barangay/search.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, List, Literal, TYPE_CHECKING
 
 import pandas as pd
@@ -30,6 +31,10 @@ def search(
 ) -> List[dict]:
     """Search barangay data with fuzzy matching.
 
+    .. deprecated::
+        search() is deprecated and will be removed in 2027.X.X.X.
+        Use search_fuzzy() instead for typed SearchResult objects.
+
     Args:
         search_string: String to search for in barangay data.
         match_hooks: List of location levels to match. Defaults to all.
@@ -42,6 +47,12 @@ def search(
     Returns:
         List of matching barangay records as dictionaries.
     """
+    warnings.warn(
+        "search() is deprecated and will be removed in 2027.X.X.X. "
+        "Use search_fuzzy() instead for typed SearchResult objects.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # Create fuzz_base if not provided
     if fuzz_base is None:
         fuzz_base = create_fuzz_base(as_of=as_of)

--- a/docs/api.md
+++ b/docs/api.md
@@ -292,6 +292,9 @@ except MultipleResultsError as e:
 
 ## Search (Dict-based)
 
+!!! warning "Deprecated"
+    `search()` returns raw dicts and will be removed in 2027.X.X.X. Use `search_fuzzy()` for typed `SearchResult` objects.
+
 Search for barangays using fuzzy string matching.
 
 ```python
@@ -428,6 +431,9 @@ if brgy:
 | `nicknames` | `Optional[List[str]]` | - | Optional list of alternative names |
 
 ### Backward Compatibility Dictionaries
+
+!!! warning "Deprecated"
+    `BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT` will be removed in 2027.X.X.X. Use the Database API instead (e.g. `barangays.get(name="Tongmageng")`, `barangays.to_frame()`).
 
 For backward compatibility, dict versions of the data are also available:
 
@@ -745,6 +751,9 @@ barangay.as_of = "2025-07-08"
 ## Data Models
 
 ### BarangayModel
+
+!!! warning "Deprecated"
+    `BarangayModel` will be removed in 2027.X.X.X. Use `AdminDivRecord` via the Database API instead.
 
 Pydantic model for barangay data validation and serialization.
 

--- a/docs/data_models/python.md
+++ b/docs/data_models/python.md
@@ -1,5 +1,8 @@
 # Python Data Models
 
+!!! warning "Deprecated"
+    This page demonstrates the legacy dict-based data models (`BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT`). These dict aliases are **deprecated** and will be removed in 2027.X.X.X. Use the [Database API](../api.md) for new code (e.g. `barangays.get(name="Tongmageng")`, `barangays.to_frame()`, hierarchy traversal via `.parent`/`.ancestors`).
+
 This package provides three data models for accessing Philippine barangay information, each optimized for different use cases.
 
 ## BARANGAY

--- a/docs/index.md
+++ b/docs/index.md
@@ -184,3 +184,6 @@ Current data version: [**2026-04-13** (April 13 2026 PSGC masterlist)](https://p
 - [Configuration](configuration.md)
 - [Plugins](plugins/index.md)
 - [Contributing](contributing/index.md)
+
+!!! warning "Deprecation Notice"
+    `BARANGAY`/`BARANGAY_EXTENDED`/`BARANGAY_FLAT` dict aliases and `search()` are deprecated and will be removed in 2027.X.X.X. Use the Database API for new code (e.g. `barangays.get(name="Tongmageng")`, `search_fuzzy("query")`). See the [API Reference](api.md) and [Database API tutorial](tutorials/database_api.md).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -132,7 +132,7 @@ Raised by `.get(name=...)` when the name matches multiple records. Use `.lookup(
 
 ---
 
-## Legacy API
+## Legacy API (Deprecated — removal in 2027.X.X.X)
 
 ### search()
 
@@ -250,6 +250,8 @@ if brgy:
 | `nicknames` | `Optional[List[str]]` | Optional list of alternative names |
 
 ### Backward Compatibility Dictionaries
+
+> **Deprecated:** `BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT` will be removed in 2027.X.X.X. Use the Database API instead (e.g. `barangays.get(name="Tongmageng")`, `barangays.to_frame()`).
 
 ```python
 from barangay import BARANGAY, BARANGAY_EXTENDED, BARANGAY_FLAT
@@ -440,6 +442,8 @@ barangay batch validate barangay_names.txt
 ---
 
 ## Data Models Overview
+
+> **Note:** The sections below describe legacy dict-based data structures (`BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT`). These are **deprecated** and will be removed in 2027.X.X.X. Use the Database API instead (e.g. `barangays.get(name="Tongmageng")`, `barangays.to_frame()`).
 
 ### BARANGAY (Nested)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -125,7 +125,7 @@ import barangay
 barangay.use_plugins(["population"], levels=[barangay.AdminLevel.CITY])
 ```
 
-## Legacy API
+## Legacy API (Deprecated — removal in 2027.X.X.X)
 
 ### Search (dict-based)
 

--- a/docs/tutorials/address_validation.md
+++ b/docs/tutorials/address_validation.md
@@ -70,6 +70,9 @@ for r in results:
 
 ## Using `search()` with Threshold
 
+!!! warning "Deprecated"
+    `search()` returns raw dicts and will be removed in 2027.X.X.X. Use `validate()` or `search_fuzzy()` for typed results.
+
 Use the `search()` function with a high threshold to validate addresses:
 
 ```python
@@ -85,6 +88,9 @@ else:
 ```
 
 ## Handling Misspellings
+
+!!! warning "Deprecated"
+    `search()` returns raw dicts and will be removed in 2027.X.X.X. Use `search_fuzzy()` for typed results.
 
 Fuzzy search tolerates typos and alternative spellings:
 
@@ -116,6 +122,9 @@ Each line in `addresses.txt` should contain one barangay name.
 
 ## Batch Search with Python
 
+!!! warning "Deprecated"
+    `search()` returns raw dicts and will be removed in 2027.X.X.X. Use `search_fuzzy()` or `validate_many()` for typed results.
+
 For programmatic batch validation:
 
 ```python
@@ -136,6 +145,9 @@ for addr in addresses:
 ```
 
 ## Custom Sanitization
+
+!!! warning "Deprecated"
+    `search()` returns raw dicts and will be removed in 2027.X.X.X. Use `search_fuzzy()` for typed results.
 
 Strip common prefixes and suffixes before matching:
 

--- a/docs/tutorials/bulk_barangay_lookup.md
+++ b/docs/tutorials/bulk_barangay_lookup.md
@@ -68,6 +68,9 @@ for r in results:
 
 ## Method 2: Python Batch Search with FuzzBase
 
+!!! note "Legacy API"
+    `search()` + `FuzzBase` is the legacy search approach. `search_fuzzy()` and Database views are recommended for new code.
+
 Reuse a `FuzzBase` instance to avoid reloading data on every search:
 
 ```python
@@ -181,7 +184,7 @@ with open("all_barangays.json", "w") as f:
 |----------|-------|----------|
 | `to_frame()` / `to_dicts()` | Fastest | Full dataset export |
 | Filter `barangay_flat` | <1ms/query | Exact or prefix matching |
-| `FuzzBase` + `search()` | ~25-80ms/query | Fuzzy matching with typos |
+| `FuzzBase` + `search()` | ~25-80ms/query | Fuzzy matching with typos (deprecated — use `search_fuzzy()` or Database views) |
 | `validate_many()` | ~25-80ms/query | Batch address validation |
 | CLI `batch-search` | Batch optimized | File-based processing |
 | `export` + external tools | Fastest | Full dataset export |


### PR DESCRIPTION
## Summary

- Add `DeprecationWarning` runtime warnings to `BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT` dict aliases, `search()` function, and `BarangayModel` class, targeting removal in **2027.X.X.X**
- Add deprecation admonitions (`!!! warning`) and notices across all documentation (README, api.md, tutorials, llms.txt, llms-full.txt, index.md, data_models)
- Replacement for all deprecated items is the **Database API** (pycountry-style: `barangays.get()`, `search_fuzzy()`, `AdminDivRecord`)

## Files changed (11)

| File | Change |
|------|--------|
| `barangay/__init__.py` | `warnings.warn()` on `BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT` |
| `barangay/search.py` | `warnings.warn()` in `search()` |
| `barangay/models.py` | `model_validator` warning on `BarangayModel` instantiation |
| `README.md` | Deprecation blockquotes (PyPI-compatible) |
| `docs/api.md` | `!!! warning` admonitions on 3 sections |
| `docs/data_models/python.md` | Deprecation banner |
| `docs/index.md` | Deprecation notice |
| `docs/tutorials/address_validation.md` | Admonitions on 4 sections |
| `docs/tutorials/bulk_barangay_lookup.md` | Admonitions on 2 sections |
| `docs/llms.txt` | Deprecated header on Legacy API section |
| `docs/llms-full.txt` | Deprecation notes on 3 sections |

## Not deprecated

Pydantic models (`barangay`, `barangay_extended`, `barangay_flat`), `FuzzBase`, `create_fuzz_base()`, `sanitize_input()`, Database API views, `search_fuzzy()`, `validate()`, `validate_many()`, `DataManager`, plugin system.

## Testing

All 381 tests pass with expected `DeprecationWarning` output. Pre-commit hooks (ruff, ruff-format, pip-audit, pytest, ty) all pass.