### PR TITLE
feat: add AGENTS.md, optimize lazy-loading and caching, fix mypy references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ Describe how you tested your changes.
 
 - [ ] Tests pass (`uv run pytest`)
 - [ ] Linting passes (`uv run ruff check .`)
-- [ ] Type checking passes (`uv run mypy`)
+- [ ] Type checking passes (`uv run ty check`)
 - [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
 
 ## Checklist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md
+
+AI coding agent reference for the **barangay** project — a Philippine Standard Geographic Code (PSGC) Python package providing offline access to all 42,011 barangays with fuzzy search, address validation, CLI, plugin system, and historical data support.
+
+See [README.md](README.md) for user-facing documentation and [docs/](docs/) for the full docs site.
+
+## Repository Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `barangay/` | Main package — core library, public API re-exports |
+| `barangay/data/` | Bundled PSGC data files (version from `CURRENT_VERSION`) |
+| `barangay/plugins/` | Plugin system |
+| `tests/` | Test suite |
+| `parsers/` | PSGC data parsing scripts (excluded from ty checking) |
+| `docs/` | MkDocs documentation source |
+| `architecture/` | Architecture decision records |
+| `.github/workflows/` | CI: publish (PyPI), docs (GitHub Pages) |
+
+## Tech Stack
+
+| Tool | Purpose |
+|------|---------|
+| Python 3.13+ | Runtime |
+| `uv` | Dependency management |
+| `hatchling` | Build system |
+| `ruff` | Linting + formatting |
+| `ty` | Type checking (NOT mypy) |
+| `pytest` + `pytest-xdist` + `pytest-cov` | Testing |
+| `pre-commit` | Pre-commit hooks |
+| `mkdocs` + `mkdocs-shadcn` | Documentation |
+| `click` + `rich` | CLI framework |
+| `poe` (poethepoet) | Task runner |
+
+## Commands
+
+```bash
+uv sync                          # Install dependencies
+uv run ruff check --fix --exit-non-zero-on-fix --ignore E741  # Lint
+uv run ruff format               # Format
+uv run ty check                  # Type check (NOT mypy)
+uv run pytest                    # Run tests (local dev)
+uv run pytest -n auto            # Run tests in parallel (pre-commit uses this)
+uv run pytest --cov              # Run tests with coverage
+uv run pre-commit run --all-files  # Run all pre-commit hooks manually
+uv build                         # Build package
+poe barpar                       # Run PSGC data parser (parsers/psgc/cli.py)
+mkdocs serve                     # Local docs preview
+```
+
+## Code Conventions
+
+- `ruff` default formatting — no custom config
+- Type hints required (`ty check` is enforced)
+- Python 3.13+ syntax allowed (e.g. `X | Y` union types, `str | None`)
+- Follow existing import ordering in neighboring files
+- Tests go in `tests/` with `test_*.py` naming
+- No comments unless explicitly requested
+
+## Branching Strategy (GitHub Flow)
+
+- `main` is the only long-lived branch
+- Feature/fix/docs branches: `feature/<name>`, `fix/<name>`, `docs/<name>`
+- PR required to merge into `main` — no direct commits
+- Tags matching `*.*.*.*` trigger PyPI publish via GitHub Actions
+
+## AI Workflow
+
+1. **Understand context** — read relevant files before making changes
+2. **Make changes** — follow existing code conventions and patterns
+3. **Run verification** before considering done:
+   ```bash
+   uv run ruff check --fix --exit-non-zero-on-fix --ignore E741
+   uv run ruff format
+   uv run ty check
+   uv run pytest
+   ```
+4. **Follow PR template** — reference CONTRIBUTING.md and PR template checklist
+
+## Testing
+
+- Test directory: `tests/`
+- Naming: `test_*.py`
+- Local dev: `uv run pytest` (sequential)
+- Pre-commit: `uv run pytest -n auto` (parallel via xdist)
+- Coverage: `uv run pytest --cov`
+- `tests/` is excluded from `ty` type checking
+
+## CI/CD
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `publish.yaml` | Tag push (`*.*.*.*`) | Build and publish to PyPI |
+| `docs.yaml` | Push to `docs/**` or `mkdocs.yml` | Build and deploy docs to GitHub Pages (deploy only from `main`) |
+
+## Notes / Gotchas
+
+- `parsers/` and `tests/` are excluded from `ty` type checking (`pyproject.toml` `[tool.ty.src]`)
+- `search()` (dict-based, deprecated) and `search_fuzzy()` (typed, recommended) coexist — always use `search_fuzzy()`
+- `BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT` dict aliases are deprecated — use Database API (`barangays.get(name=...)`)
+- CLI entry point: `barangay.cli:app`
+- `barpar` poe task = `python parsers/psgc/cli.py` (PSGC data parsing)
+- Data version comes from `barangay/data/CURRENT_VERSION` file, not hardcoded
+- Module-level attributes: `barangay.current`, `barangay.as_of`, `barangay.available_dates`
+- Public API re-exports are defined in `barangay/__init__.py` — check `__all__` for the full list

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 
 We use `pre-commit` to ensure code quality. The following hooks are configured:
 - **Ruff**: For linting and formatting.
-- **Mypy**: For static type checking.
+- **Ty**: For static type checking.
 - **Pip-audit**: To check for known vulnerabilities in dependencies.
 - **Pytest**: To run the test suite.
 

--- a/barangay/__init__.py
+++ b/barangay/__init__.py
@@ -17,17 +17,14 @@ current: str = _current
 as_of: str | None = None
 available_dates: list[str] = []
 
-# Import data
+# Import data (lazy - actual data loads deferred until first access)
+import barangay.data as _data_module  # noqa:E402
+
 from barangay.config import (  # noqa:E402
     get_cache_dir,
     get_verbose,
     load_env_config,
     resolve_as_of,
-)
-from barangay.data import (  # noqa:E402
-    barangay,
-    barangay_extended,
-    barangay_flat,
 )
 
 # Import new components
@@ -87,54 +84,24 @@ _VIEW_NAMES = frozenset(
     }
 )
 
-# Backward compatibility aliases
-# Note: These convert Pydantic models to dicts at module import time.
-# DEPRECATED: These dict aliases will be removed in 2027.X.X.X.
-# Use the Database API instead (e.g. `from barangay import barangays; barangays.get(name="Tongmageng")`).
+_DEPRECATED_NAMES = frozenset({"BARANGAY", "BARANGAY_EXTENDED", "BARANGAY_FLAT"})
+_LAZY_DATA_NAMES = frozenset({"barangay", "barangay_extended", "barangay_flat"})
 
-warnings.warn(
-    "BARANGAY is deprecated and will be removed in 2027.X.X.X. "
-    "Use the Database API instead: "
-    "from barangay import barangays; barangays.get(name='Tongmageng')",
-    DeprecationWarning,
-    stacklevel=2,
-)
-BARANGAY: dict[str, Any] = barangay.model_dump()
-
-warnings.warn(
-    "BARANGAY_EXTENDED is deprecated and will be removed in 2027.X.X.X. "
-    "Use the Database API instead: hierarchy traversal via .parent, .ancestors, .children "
-    "(e.g. from barangay import barangays; rec = barangays.get(name='Tongmageng'); rec.parent)",
-    DeprecationWarning,
-    stacklevel=2,
-)
-BARANGAY_EXTENDED: dict[str, Any] = barangay_extended.model_dump()
-
-warnings.warn(
-    "BARANGAY_FLAT is deprecated and will be removed in 2027.X.X.X. "
-    "Use the Database API instead: to_frame(), to_dicts(), iteration "
-    "(e.g. from barangay import barangays; barangays.to_frame())",
-    DeprecationWarning,
-    stacklevel=2,
-)
-BARANGAY_FLAT: list[dict[str, Any]] = [x.model_dump() for x in barangay_flat]
+_BARANGAY_CACHE: dict[str, Any] | None = None
+_BARANGAY_EXTENDED_CACHE: dict[str, Any] | None = None
+_BARANGAY_FLAT_CACHE: list[dict[str, Any]] | None = None
 
 __all__ = [
-    # Main search function
     "search",
-    # Classes
     "FuzzBase",
     "BarangayModel",
     "DataManager",
     "PluginLoader",
-    # Data
     "BARANGAY",
     "BARANGAY_EXTENDED",
     "BARANGAY_FLAT",
-    # Utilities
     "sanitize_input",
     "to_python_identifier",
-    # New components
     "create_fuzz_base",
     "get_available_dates",
     "resolve_date",
@@ -142,11 +109,9 @@ __all__ = [
     "get_verbose",
     "load_env_config",
     "resolve_as_of",
-    # Module-level attributes
     "current",
     "as_of",
     "available_dates",
-    # Database API
     "Database",
     "DatabaseView",
     "EnrichedRecord",
@@ -155,7 +120,6 @@ __all__ = [
     "SearchResult",
     "ValidationResult",
     "PluginInfo",
-    # Database namespaces
     "regions",
     "provinces",
     "municipalities",
@@ -163,7 +127,6 @@ __all__ = [
     "submunicipalities",
     "barangays",
     "special_geographic_areas",
-    # New functions
     "search_fuzzy",
     "validate",
     "validate_many",
@@ -178,6 +141,48 @@ __all__ = [
 
 
 def __getattr__(name: str):
+    global _BARANGAY_CACHE, _BARANGAY_EXTENDED_CACHE, _BARANGAY_FLAT_CACHE
+
     if name in _VIEW_NAMES:
         return getattr(_db, name)
+
+    if name in _LAZY_DATA_NAMES:
+        return getattr(_data_module, name)
+
+    if name == "BARANGAY":
+        if _BARANGAY_CACHE is None:
+            warnings.warn(
+                "BARANGAY is deprecated and will be removed in 2027.X.X.X. "
+                "Use the Database API instead: "
+                "from barangay import barangays; barangays.get(name='Tongmageng')",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _BARANGAY_CACHE = _data_module.barangay.model_dump()
+        return _BARANGAY_CACHE
+
+    if name == "BARANGAY_EXTENDED":
+        if _BARANGAY_EXTENDED_CACHE is None:
+            warnings.warn(
+                "BARANGAY_EXTENDED is deprecated and will be removed in 2027.X.X.X. "
+                "Use the Database API instead: hierarchy traversal via .parent, .ancestors, .children "
+                "(e.g. from barangay import barangays; rec = barangays.get(name='Tongmageng'); rec.parent)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _BARANGAY_EXTENDED_CACHE = _data_module.barangay_extended.model_dump()
+        return _BARANGAY_EXTENDED_CACHE
+
+    if name == "BARANGAY_FLAT":
+        if _BARANGAY_FLAT_CACHE is None:
+            warnings.warn(
+                "BARANGAY_FLAT is deprecated and will be removed in 2027.X.X.X. "
+                "Use the Database API instead: to_frame(), to_dicts(), iteration "
+                "(e.g. from barangay import barangays; barangays.to_frame())",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _BARANGAY_FLAT_CACHE = [x.model_dump() for x in _data_module.barangay_flat]
+        return _BARANGAY_FLAT_CACHE
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/barangay/data.py
+++ b/barangay/data.py
@@ -23,7 +23,7 @@ _FUZZER_BASE_FILENAME = data_dir / "fuzzer_base.parquet"
 
 _data_manager = DataManager()
 
-__all__ = [
+__all__ = [  # noqa: F822
     "barangay",
     "barangay_extended",
     "barangay_flat",
@@ -67,7 +67,33 @@ def load_fuzzer_base(as_of: str | None = None) -> pd.DataFrame:
     return data
 
 
-barangay: AdminDiv = load_barangay_data()
-barangay_extended: AdminDivExtended = load_barangay_extended_data()
-barangay_flat: list[AdminDivFlat] = load_barangay_flat_data()
-_fuzzer_base_df = load_fuzzer_base()
+_barangay: AdminDiv | None = None
+_barangay_extended: AdminDivExtended | None = None
+_barangay_flat: list[AdminDivFlat] | None = None
+_fuzzer_base_df: pd.DataFrame | None = None
+
+_LAZY_ATTRS = {"barangay", "barangay_extended", "barangay_flat", "_fuzzer_base_df"}
+
+
+def __getattr__(name: str):
+    global _barangay, _barangay_extended, _barangay_flat, _fuzzer_base_df
+    if name not in _LAZY_ATTRS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    if name == "barangay":
+        if _barangay is None:
+            _barangay = load_barangay_data()
+        return _barangay
+    if name == "barangay_extended":
+        if _barangay_extended is None:
+            _barangay_extended = load_barangay_extended_data()
+        return _barangay_extended
+    if name == "barangay_flat":
+        if _barangay_flat is None:
+            _barangay_flat = load_barangay_flat_data()
+        return _barangay_flat
+    if name == "_fuzzer_base_df":
+        if _fuzzer_base_df is None:
+            _fuzzer_base_df = load_fuzzer_base()
+        return _fuzzer_base_df
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/barangay/data_manager.py
+++ b/barangay/data_manager.py
@@ -36,6 +36,7 @@ class DataManager:
     def __init__(self):
         self._cache_dir: Path = self._get_cache_dir()
         self._logged_dataset = False
+        self._memory_cache: dict[str, dict | list[dict] | pd.DataFrame] = {}
 
     @overload
     def get_data(self, as_of: str | None, data_type: Literal["basic"]) -> dict: ...
@@ -67,16 +68,23 @@ class DataManager:
 
         self._log_dataset_info(status_message, get_verbose())
 
+        cache_key = f"{resolved_date or 'default'}_{data_type}"
+        if cache_key in self._memory_cache:
+            return self._memory_cache[cache_key]
+
         if resolved_date is None:
-            return self._load_from_package(data_type)
+            result = self._load_from_package(data_type)
         elif resolved_date == CURRENT_DATE:
-            return self._load_from_package(data_type)
+            result = self._load_from_package(data_type)
         else:
             cached_data = self._load_from_cache(resolved_date, data_type)
             if cached_data is not None:
-                return cached_data
+                result = cached_data
+            else:
+                result = self._download_from_github(resolved_date, data_type)
 
-            return self._download_from_github(resolved_date, data_type)
+        self._memory_cache[cache_key] = result
+        return result
 
     def _load_from_package(self, data_type: str) -> dict | list[dict] | pd.DataFrame:
         from importlib import resources
@@ -171,6 +179,9 @@ class DataManager:
                 raise ValueError("Data must be a DataFrame for parquet files")
         else:
             raise ValueError(f"Unsupported file type: {filename}")
+
+    def invalidate_memory_cache(self) -> None:
+        self._memory_cache.clear()
 
     def _log_dataset_info(self, status_message: str, verbose: bool) -> None:
         if not verbose or self._logged_dataset:

--- a/barangay/fuzz.py
+++ b/barangay/fuzz.py
@@ -10,6 +10,7 @@ from barangay.utils import _basic_sanitizer
 __all__ = [
     "FuzzBase",
     "create_fuzz_base",
+    "invalidate_fuzz_cache",
 ]
 
 
@@ -81,9 +82,17 @@ class FuzzBase:
         )
 
 
+_fuzz_base_cache: dict[str | None, FuzzBase] = {}
+
+
 def create_fuzz_base(as_of: str | None = None) -> FuzzBase:
+    if as_of in _fuzz_base_cache:
+        return _fuzz_base_cache[as_of]
     fuzzer_base = load_fuzzer_base(as_of=as_of)
-    return FuzzBase(fuzzer_base=fuzzer_base)
+    fb = FuzzBase(fuzzer_base=fuzzer_base)
+    _fuzz_base_cache[as_of] = fb
+    return fb
 
 
-_default_fuzz_base = FuzzBase(fuzzer_base=load_fuzzer_base())
+def invalidate_fuzz_cache() -> None:
+    _fuzz_base_cache.clear()

--- a/barangay/search.py
+++ b/barangay/search.py
@@ -3,17 +3,12 @@ from typing import TYPE_CHECKING, Any, Callable, List, Literal
 
 import pandas as pd
 
-from barangay.data import load_fuzzer_base
 from barangay.fuzz import FuzzBase, create_fuzz_base
 from barangay.types import MatchHook
 from barangay.utils import _basic_sanitizer
 
 if TYPE_CHECKING:
     from barangay.models import AdminLevel, SearchResult
-
-
-# Create default fuzz base instance (backward compatibility)
-_default_fuzz_base = FuzzBase(fuzzer_base=load_fuzzer_base())
 
 
 def search(

--- a/barangay/version.py
+++ b/barangay/version.py
@@ -15,10 +15,14 @@ def use_version(as_of: str | None) -> None:
         barangay.use_version(None)
     """
     from barangay.database import Database
+    from barangay.data_manager import DataManager
+    from barangay.fuzz import invalidate_fuzz_cache
 
     db = Database()
     db._version_state.set(as_of)
     db.invalidate_cache()
+    DataManager().invalidate_memory_cache()
+    invalidate_fuzz_cache()
 
 
 def use_plugins(

--- a/tests/test_cache_with_as_of.py
+++ b/tests/test_cache_with_as_of.py
@@ -1,0 +1,200 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from barangay.data_manager import DataManager
+from barangay.database import Database
+from barangay.fuzz import _fuzz_base_cache, create_fuzz_base, invalidate_fuzz_cache
+from barangay.plugin_loader import (
+    PluginLoader,
+    load_plugin_data,
+)
+from barangay.version import use_version
+
+
+def _create_plugin(tmp_path, name, manifest, data_files):
+    plugin_dir = tmp_path / name
+    plugin_dir.mkdir()
+    (plugin_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+    data_dir = plugin_dir / "data"
+    data_dir.mkdir()
+    for filename, content in data_files.items():
+        filepath = data_dir / filename
+        filepath.write_text(content) if isinstance(
+            content, str
+        ) else filepath.write_bytes(content)
+    return plugin_dir
+
+
+def _make_manifest(name, fmt="csv", key="psgc_id", **overrides):
+    manifest = {"name": name, "format": fmt, "key": key, **overrides}
+    return manifest
+
+
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    yield
+    use_version(None)
+    invalidate_fuzz_cache()
+
+
+class TestDataManagerMemoryCacheWithAsOf:
+    @patch("barangay.date_resolver.get_available_dates", return_value=["2025-01-01"])
+    def test_historical_date_creates_dated_cache_key(self, _mock_dates):
+        dm = DataManager()
+        fixture_data = {"test": True}
+        with patch.object(dm, "_download_from_github", return_value=fixture_data):
+            result = dm.get_data(as_of="2025-01-01", data_type="basic")
+
+        assert "2025-01-01_basic" in dm._memory_cache
+        assert dm._memory_cache["2025-01-01_basic"] is result
+
+    @patch("barangay.date_resolver.get_available_dates", return_value=["2025-01-01"])
+    def test_same_as_of_returns_cached_result(self, _mock_dates):
+        dm = DataManager()
+        fixture_data = {"test": True}
+        with patch.object(
+            dm, "_download_from_github", return_value=fixture_data
+        ) as mock_dl:
+            dm.get_data(as_of="2025-01-01", data_type="basic")
+            dm.get_data(as_of="2025-01-01", data_type="basic")
+
+        mock_dl.assert_called_once()
+
+    @patch(
+        "barangay.date_resolver.get_available_dates",
+        return_value=["2025-01-01", "2025-06-01"],
+    )
+    def test_different_as_of_creates_separate_cache_entry(self, _mock_dates):
+        dm = DataManager()
+        data_1 = {"version": 1}
+        data_2 = {"version": 2}
+        with patch.object(dm, "_download_from_github", side_effect=[data_1, data_2]):
+            r1 = dm.get_data(as_of="2025-01-01", data_type="basic")
+            r2 = dm.get_data(as_of="2025-06-01", data_type="basic")
+
+        assert r1 is not r2
+        assert "2025-01-01_basic" in dm._memory_cache
+        assert "2025-06-01_basic" in dm._memory_cache
+        assert dm._memory_cache["2025-01-01_basic"] == {"version": 1}
+        assert dm._memory_cache["2025-06-01_basic"] == {"version": 2}
+
+    @patch("barangay.date_resolver.get_available_dates", return_value=["2025-01-01"])
+    def test_default_key_is_separate_from_historical(self, _mock_dates):
+        dm = DataManager()
+        default_result = dm.get_data(as_of=None, data_type="basic")
+
+        assert "default_basic" in dm._memory_cache
+        assert "2025-01-01_basic" not in dm._memory_cache
+
+        fixture_data = {"historical": True}
+        with patch.object(dm, "_download_from_github", return_value=fixture_data):
+            hist_result = dm.get_data(as_of="2025-01-01", data_type="basic")
+
+        assert dm._memory_cache["default_basic"] is default_result
+        assert dm._memory_cache["2025-01-01_basic"] is hist_result
+
+
+class TestFuzzBaseCacheWithAsOf:
+    def test_same_as_of_returns_same_object(self):
+        fb1 = create_fuzz_base(as_of=None)
+        fb2 = create_fuzz_base(as_of=None)
+        assert fb1 is fb2
+
+    def test_historical_as_of_is_cached(self):
+        fb1 = create_fuzz_base(as_of=None)
+        assert None in _fuzz_base_cache
+        assert _fuzz_base_cache[None] is fb1
+
+    def test_different_as_of_creates_separate_entry(self):
+        invalidate_fuzz_cache()
+        create_fuzz_base(as_of=None)
+        assert len(_fuzz_base_cache) == 1
+
+    def test_invalidate_clears_all_entries(self):
+        create_fuzz_base(as_of=None)
+        assert len(_fuzz_base_cache) >= 1
+        invalidate_fuzz_cache()
+        assert len(_fuzz_base_cache) == 0
+
+
+class TestDatabaseSingletonCacheWithAsOf:
+    @pytest.fixture(autouse=True)
+    def reset_db_singleton(self):
+        Database._instance = None
+        yield
+        Database._instance = None
+
+    def test_ensure_loaded_short_circuits(self):
+        db = Database()
+        db._ensure_loaded()
+        assert db._raw_records is not None
+
+        records_id = id(db._raw_records)
+        db._ensure_loaded()
+        assert id(db._raw_records) == records_id
+
+    def test_version_switch_invalidates_cache(self):
+        db = Database()
+        db._ensure_loaded()
+        assert db._raw_records is not None
+
+        use_version("2025-07-08")
+        assert db._raw_records is None
+
+        db._ensure_loaded()
+        assert db._raw_records is not None
+
+    def test_ensure_loaded_with_plugin_calls_build_index_once(self, tmp_path):
+        csv_content = "psgc_id,population\n001,1000\n"
+        _create_plugin(tmp_path, "pop", _make_manifest("pop"), {"pop.csv": csv_content})
+        (tmp_path / "plugins.yaml").write_text(
+            yaml.dump({"plugins": [{"name": "pop", "enabled": True}]})
+        )
+
+        loader = PluginLoader(env=False, extra_dirs=[tmp_path])
+        mock_loader = MagicMock(wraps=loader)
+        mock_loader.build_index = MagicMock(wraps=loader.build_index)
+
+        db = Database()
+        db.use_plugins(plugins=["pop"], loader=mock_loader)
+
+        db._ensure_loaded()
+        db._ensure_loaded()
+
+        mock_loader.build_index.assert_called_once()
+
+
+class TestPluginDiskCacheWithAsOf:
+    @patch("barangay.plugin_loader._fetch_remote_data_file")
+    def test_disk_cache_hit_avoids_network(self, mock_fetch, tmp_path):
+        json_content = json.dumps([{"psgc_id": "001", "value": 42}])
+        cache_dir = tmp_path / "cache"
+        plugin_cache_dir = cache_dir / "plugins"
+        plugin_cache_dir.mkdir(parents=True)
+
+        def write_and_return(url, plugin_name, cache_dir=None):
+            actual_dir = cache_dir if cache_dir else plugin_cache_dir
+            actual_dir.mkdir(parents=True, exist_ok=True)
+            out = actual_dir / "demo_demo.json"
+            out.write_text(json_content)
+            return out
+
+        mock_fetch.side_effect = write_and_return
+
+        manifest = _make_manifest(
+            "demo", fmt="json", repository="https://github.com/user/repo"
+        )
+        _create_plugin(tmp_path, "demo", manifest, {})
+
+        with patch("barangay.plugin_loader.get_cache_dir", return_value=cache_dir):
+            load_plugin_data(
+                manifest, resolved_date="2025-01-01", plugin_dirs=[tmp_path]
+            )
+            load_plugin_data(
+                manifest, resolved_date="2025-01-01", plugin_dirs=[tmp_path]
+            )
+
+        mock_fetch.assert_called_once()


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` for AI coding agent context, optimizes module import performance via lazy-loading and caching, and fixes stale `mypy` references to `ty` across documentation.

## Changes

- **New `AGENTS.md`**: AI-facing reference with repo structure, tech stack, commands, conventions, branching strategy, CI/CD, and gotchas
- **Lazy-loading in `barangay/data.py`**: Data models (`barangay`, `barangay_extended`, `barangay_flat`, `_fuzzer_base_df`) now load on first access via `__getattr__` instead of eagerly at import time
- **Lazy deprecated aliases in `barangay/__init__.py`**: `BARANGAY`, `BARANGAY_EXTENDED`, `BARANGAY_FLAT` dict aliases moved to `__getattr__` with caching — no longer trigger deprecation warnings at import
- **In-memory cache in `DataManager`**: Avoids redundant disk reads/network calls when the same `(as_of, data_type)` is requested multiple times
- **`FuzzBase` instance cache**: `create_fuzz_base()` caches results by `as_of` date
- **Cache invalidation via `use_version()`**: Switching data versions now clears all caches (DataManager, Database, FuzzBase)
- **New tests**: `tests/test_cache_with_as_of.py` covering DataManager memory cache, FuzzBase cache, Database singleton, and plugin disk cache
- **Fix `CONTRIBUTING.md`**: Mypy → Ty
- **Fix `.github/PULL_REQUEST_TEMPLATE.md`**: `uv run mypy` → `uv run ty check`

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Refactor / cleanup

## Testing

- [x] Tests pass (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Type checking passes (`uv run ty check`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)

New test file `tests/test_cache_with_as_of.py` covers:
- DataManager memory cache with different `as_of` dates
- FuzzBase instance caching and invalidation
- Database singleton cache behavior on version switch
- Plugin disk cache hit avoiding redundant network calls

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)