### PR TITLE
release: v2026.4.13.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Package Version
       description: Output of `pip show barangay` or the version from pyproject.toml.
-      placeholder: "e.g., 2026.4.13.2"
+      placeholder: "e.g., 2026.4.13.3"
     validations:
       required: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barangay"
-version = "2026.4.13.2"
+version = "2026.4.13.3"
 description = "Philippines Standard Geographic Code (PSGC) 2026 Python package, Fuzzy Search, JSON, and YAML."
 authors = [{ name = "bendlikeabamboo", email = "mbalmeo32@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "barangay"
-version = "2026.4.13.2"
+version = "2026.4.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Pre-release routine for version `2026.4.13.3`. Bumps package version and updates references.

## Related Issue

N/A

## Changes

- Bumped `pyproject.toml` version from `2026.4.13.2` to `2026.4.13.3`
- Updated `uv.lock` with new version
- Updated bug report template version placeholder to `2026.4.13.3`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Data update (PSGC dataset)
- [ ] Refactor / cleanup

## Testing

- [x] Tests pass (`uv run pytest`) — 398 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Type checking passes (`uv run ty check`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)