### PR TITLE
release: 2026.4.13.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Package Version
       description: Output of `pip show barangay` or the version from pyproject.toml.
-      placeholder: "e.g., 2026.4.13.3"
+      placeholder: "e.g., 2026.4.13.4"
     validations:
       required: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barangay"
-version = "2026.4.13.3"
+version = "2026.4.13.4"
 description = "Philippines Standard Geographic Code (PSGC) 2026 Python package, Fuzzy Search, JSON, and YAML."
 authors = [{ name = "bendlikeabamboo", email = "mbalmeo32@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "barangay"
-version = "2026.4.13.3"
+version = "2026.4.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release bump for **2026.4.13.4** — ships the breaking-change feature set from #77 (roman numeral standardization, multi-level matching, accurate database view) on the existing 2026-04-13 PSGC dataset.

## Related Issue

Closes #

## Changes

- Bump version `2026.4.13.3` → `2026.4.13.4`:
  - `pyproject.toml`
  - `uv.lock` (via `uv lock`)
  - `.github/ISSUE_TEMPLATE/bug_report.yml` example placeholder

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Data update (PSGC dataset)
- [x] Refactor / cleanup

## Testing

- [x] Tests pass (`uv run pytest`) — 449 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Type checking passes (`uv run ty check`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

> Note: Merging this PR and tagging `v2026.4.13.4` triggers the PyPI publish workflow (`*.*.*.*` tag → `publish.yaml`).